### PR TITLE
Add patch which corrects gfortran.texi

### DIFF
--- a/rhel6/devtoolset-2-gcc-4.8.blp.el6.spec
+++ b/rhel6/devtoolset-2-gcc-4.8.blp.el6.spec
@@ -2,6 +2,7 @@
 %{?scl:%global __strip strip}
 %{?scl:%global __objdump objdump}
 %global _default_patch_fuzz 2
+%global _default_patch_flags -l
 %global DATE 20140120
 %global SVNREV 206854
 %global gcc_version 4.8.2
@@ -330,6 +331,7 @@ Patch3046: 0046-Remove-all-references-to-foracle-support-this-is-now.patch
 Patch3047: 0047-Revert-all-previous-support-for-STRUCTURE.patch
 Patch3048: 0048-STRUCTURE-UNION-and-MAP-support.patch
 Patch3049: 0049-union-fix-for-rhel6.patch
+Patch3050: 0050-Fixes-to-gfortran.texi.patch
 
 %if 0%{?rhel} >= 7
 %global nonsharedver 48
@@ -685,6 +687,7 @@ cd ..
 %patch3047 -p1 -b .blp0047~
 %patch3048 -p1 -b .blp0048~
 %patch3049 -p1 -b .blp0049~
+%patch3050 -p1 -b .blp0050~
 
 sed -i -e 's/4\.8\.3/4.8.2/' gcc/BASE-VER
 echo 'Red Hat %{version}-%{gcc_release}' > gcc/DEV-PHASE

--- a/rhel6/patches/0050-Fixes-to-gfortran.texi.patch
+++ b/rhel6/patches/0050-Fixes-to-gfortran.texi.patch
@@ -1,0 +1,94 @@
+diff --git a/gcc/fortran/gfortran.texi b/gcc/fortran/gfortran.texi
+index 451eb59..7b1d9a7 100644
+--- a/gcc/fortran/gfortran.texi
++++ b/gcc/fortran/gfortran.texi
+@@ -1320,10 +1320,10 @@ extensions.
+ 
+ @menu
+ * Extensions implemented in GNU Fortran::
++* Optional DEC extension support::
+ * Extensions not implemented in GNU Fortran::
+ @end menu
+ 
+-
+ @node Extensions implemented in GNU Fortran
+ @section Extensions implemented in GNU Fortran
+ @cindex extensions, implemented
+@@ -1980,7 +1980,7 @@ AUTOMATIC forces all variable declared with it to be on the stack.
+ AUTOMATIC overrides -fno-automatic.
+ 
+ @node Optional DEC extension support
+-@subsection Optional DEC extension support
++@section Optional DEC extension support
+ @cindex extensions, dec
+ 
+ Long long ago in a land far far away, in the time before Fortran standards
+@@ -2002,7 +2002,7 @@ described here.
+ @end menu
+ 
+ @node STRUCTURE and RECORD
+-@subsubsection @code{STRUCTURE} and @code{RECORD}
++@subsection @code{STRUCTURE} and @code{RECORD}
+ @cindex @code{STRUCTURE}
+ @cindex @code{RECORD}
+ 
+@@ -2146,7 +2146,7 @@ those described in @ref{Old-style variable initialization}.
+ @end itemize
+ 
+ @node UNION and MAP
+-@subsubsection @code{UNION} and @code{MAP}
++@subsection @code{UNION} and @code{MAP}
+ @cindex @code{UNION}
+ @cindex @code{MAP}
+ 
+@@ -2247,6 +2247,31 @@ a.rx = z'AABBCCCCFFFFFFFF'
+ !  a.l == z'AA'
+ @end example
+ 
++
++@node Extensions not implemented in GNU Fortran
++@section Extensions not implemented in GNU Fortran
++@cindex extensions, not implemented
++
++The long history of the Fortran language, its wide use and broad
++userbase, the large number of different compiler vendors and the lack of
++some features crucial to users in the first standards have lead to the
++existence of a number of important extensions to the language.  While
++some of the most useful or popular extensions are supported by the GNU
++Fortran compiler, not all existing extensions are supported.  This section
++aims at listing these extensions and offering advice on how best make
++code that uses them running with the GNU Fortran compiler.
++
++@c More can be found here:
++@c   -- http://gcc.gnu.org/onlinedocs/gcc-3.4.6/g77/Missing-Features.html
++@c   -- the list of Fortran and libgfortran bugs closed as WONTFIX:
++@c      http://tinyurl.com/2u4h5y
++
++@menu
++* ENCODE and DECODE statements::
++* Variable FORMAT expressions::
++* Alternate complex function syntax::
++@end menu
++
+ @node ENCODE and DECODE statements
+ @subsection @code{ENCODE} and @code{DECODE} statements
+ @cindex @code{ENCODE}
+@@ -2352,8 +2377,6 @@ well as @code{COMPLEX*16 FUNCTION name()}.  Both are non-standard, legacy
+ extensions.  @command{gfortran} accepts the latter form, which is more
+ common, but not the former.
+ 
+-
+-
+ @c ---------------------------------------------------------------------
+ @c Mixed-Language Programming
+ @c ---------------------------------------------------------------------
+@@ -2374,7 +2397,6 @@ if one links Fortran code compiled by different compilers.  In most cases,
+ use of the C Binding features of the Fortran 2003 standard is sufficient,
+ and their use is highly recommended.
+ 
+-
+ @node Interoperability with C
+ @section Interoperability with C
+ 
+-- 
+2.5.0


### PR DESCRIPTION
Apparently gfortran.texi has been broken since patch 48 but this went unnoticed since gcc doesn't build documentation if texinfo isn't installed on the build machine.
