### PR TITLE
Fixes to whitespace and 'field' null check in trans-expr.c

### DIFF
--- a/rhel6/patches/0000-decl.c-variable_decl-Reject-old-style-initialization.patch
+++ b/rhel6/patches/0000-decl.c-variable_decl-Reject-old-style-initialization.patch
@@ -22,15 +22,15 @@ index 7dec803..9292418a 100644
 +++ b/gcc/fortran/decl.c
 @@ -1996,6 +1996,13 @@ variable_decl (int elem)
        if (gfc_notify_std (GFC_STD_GNU, "Old-style "
-                          "initialization at %C") == FAILURE)
-        return MATCH_ERROR;
+ 			  "initialization at %C") == FAILURE)
+ 	return MATCH_ERROR;
 +      else if (gfc_current_state () == COMP_DERIVED)
-+       {
-+         gfc_error ("Invalid old style initialization for derived type "
-+                    "component at %C");
-+         m = MATCH_ERROR;
-+         goto cleanup;
-+       }
++	{
++	  gfc_error ("Invalid old style initialization for derived type "
++		     "component at %C");
++	  m = MATCH_ERROR;
++	  goto cleanup;
++	}
 
        return match_old_style_init (name);
      }

--- a/rhel6/patches/0048-STRUCTURE-UNION-and-MAP-support.patch
+++ b/rhel6/patches/0048-STRUCTURE-UNION-and-MAP-support.patch
@@ -5539,7 +5539,7 @@ index 456b2ce..ccb611d 100644
  
 @@ -1560,15 +1561,20 @@ gfc_conv_component_ref (gfc_se * se, gfc_ref * ref)
    field = c->backend_decl;
-   gcc_assert (field && TREE_CODE (field) == FIELD_DECL);
+   gcc_assert (TREE_CODE (field) == FIELD_DECL);
    decl = se->expr;
 +  context = DECL_FIELD_CONTEXT (field);
  


### PR DESCRIPTION
This allows us to return to fuzz level 1 and remove the '-l' flag to patch.
