### PR TITLE
Add UNION & MAP support patches to RHEL7

### DIFF
--- a/rhel7/gcc.4.8.5-4.el7.spec
+++ b/rhel7/gcc.4.8.5-4.el7.spec
@@ -281,6 +281,9 @@ Patch3044: 0044-Only-allow-redefinition-of-procedure-type-with-std-e.patch
 Patch3045: 0045-Correct-warnings-expected-in-hollerith-int-compariso.patch
 Patch3046: 0046-Improved-support-for-STRUCTURE-add-_SI-to-the-name-o.patch
 Patch3047: 0047-Remove-all-references-to-foracle-support-this-is-now.patch
+Patch3048: 0048-Revert-all-previous-support-for-STRUCTURE.patch
+Patch3049: 0049-STRUCTURE-UNION-and-MAP-support.patch
+Patch3050: 0050-Fixes-to-gfortran.texi.patch
 
 # On ARM EABI systems, we do want -gnueabi to be part of the
 # target triple.
@@ -1084,6 +1087,9 @@ tar xjf %{SOURCE10}
 %patch3045 -p1 -b .blp0045~
 %patch3046 -p1 -b .blp0046~
 %patch3047 -p1 -b .blp0047~
+%patch3048 -p1 -b .blp0048~
+%patch3049 -p1 -b .blp0049~
+%patch3050 -p1 -b .blp0050~
 
 
 sed -i -e 's/4\.8\.5/4.8.5/' gcc/BASE-VER

--- a/rhel7/patches/0048-Revert-all-previous-support-for-STRUCTURE.patch
+++ b/rhel7/patches/0048-Revert-all-previous-support-for-STRUCTURE.patch
@@ -1,0 +1,394 @@
+From c89e303e196290bbe4c03fc4c994a11ec00bac5d Mon Sep 17 00:00:00 2001
+From: Jim MacArthur <jim.macarthur@codethink.co.uk>
+Date: Thu, 17 Mar 2016 15:12:58 +0000
+Subject: [PATCH 48/55] Revert all previous support for STRUCTURE.
+
+This reverts commits:
+* 6c9bd7d42a37b5c405f9b4d5d51809f5360f5af0
+* a0e1e561c30e916868b9a857c35b1194dab0426a
+* 183f4567c901b5a379cf12311b95559f3b4b298b
+* 1267a29dd117a82243dea91d7b7586912da13ca3
+---
+ gcc/fortran/decl.c     | 101 +++++++++----------------------------------------
+ gcc/fortran/gfortran.h |   2 +-
+ gcc/fortran/match.c    |   4 +-
+ gcc/fortran/match.h    |   1 -
+ gcc/fortran/matchexp.c |  12 +++---
+ gcc/fortran/parse.c    |   1 -
+ gcc/fortran/primary.c  |  24 +-----------
+ 7 files changed, 27 insertions(+), 118 deletions(-)
+
+diff --git a/gcc/fortran/decl.c b/gcc/fortran/decl.c
+index e4ea22b..8ff7bca 100644
+--- a/gcc/fortran/decl.c
++++ b/gcc/fortran/decl.c
+@@ -2654,9 +2654,7 @@ gfc_match_decl_type_spec (gfc_typespec *ts, int implicit_flag)
+   match m;
+   char c;
+   bool seen_deferred_kind, matched_type;
+-  char closed_type_string[3];
+-  char closing_character;
+-  const char *dt_name, *fn_name;
++  const char *dt_name;
+ 
+   /* A belt and braces check that the typespec is correctly being treated
+      as a deferred characteristic association.  */
+@@ -2689,27 +2687,14 @@ gfc_match_decl_type_spec (gfc_typespec *ts, int implicit_flag)
+     }
+ 
+ 
+-  closing_character = ')';
+   m = gfc_match (" type (");
+-  if(m != MATCH_YES)
+-    {
+-      m = gfc_match (" record (");
+-      if(m != MATCH_YES)
+-	{
+-	  m = gfc_match (" record /");
+-	  if(m == MATCH_YES)
+-	    closing_character = '/';
+-	}
+-    }
+-
+   matched_type = (m == MATCH_YES);
+   if (matched_type)
+     {
+       gfc_gobble_whitespace ();
+       if (gfc_peek_ascii_char () == '*')
+ 	{
+-	  snprintf(closed_type_string, 3, "*%c", closing_character);
+-	  if ((m = gfc_match (closed_type_string)) != MATCH_YES)
++	  if ((m = gfc_match ("*)")) != MATCH_YES)
+ 	    return m;
+ 	  if (gfc_current_state () == COMP_DERIVED)
+ 	    {
+@@ -2749,7 +2734,7 @@ gfc_match_decl_type_spec (gfc_typespec *ts, int implicit_flag)
+       else
+ 	m = MATCH_YES;
+ 
+-      if (matched_type && m == MATCH_YES && gfc_match_char (closing_character) != MATCH_YES)
++      if (matched_type && m == MATCH_YES && gfc_match_char (')') != MATCH_YES)
+ 	m = MATCH_ERROR;
+ 
+       return m;
+@@ -2773,7 +2758,7 @@ gfc_match_decl_type_spec (gfc_typespec *ts, int implicit_flag)
+ 	  && gfc_notify_std (GFC_STD_F2008, "TYPE with "
+ 			  "intrinsic-type-spec at %C") == FAILURE)
+ 	return MATCH_ERROR;
+-      if (matched_type && gfc_match_char (closing_character) != MATCH_YES)
++      if (matched_type && gfc_match_char (')') != MATCH_YES)
+ 	return MATCH_ERROR;
+ 
+       ts->type = BT_REAL;
+@@ -2804,7 +2789,7 @@ gfc_match_decl_type_spec (gfc_typespec *ts, int implicit_flag)
+ 			  "intrinsic-type-spec at %C") == FAILURE)
+ 	return MATCH_ERROR;
+ 
+-      if (matched_type && gfc_match_char (closing_character) != MATCH_YES)
++      if (matched_type && gfc_match_char (')') != MATCH_YES)
+ 	return MATCH_ERROR;
+ 
+       ts->type = BT_COMPLEX;
+@@ -2821,7 +2806,7 @@ gfc_match_decl_type_spec (gfc_typespec *ts, int implicit_flag)
+     }
+ 
+   if (matched_type)
+-    m = gfc_match_char (closing_character);
++    m = gfc_match_char (')');
+ 
+   if (m == MATCH_YES)
+     ts->type = BT_DERIVED;
+@@ -2899,30 +2884,14 @@ gfc_match_decl_type_spec (gfc_typespec *ts, int implicit_flag)
+   dt_name = gfc_get_string ("%c%s",
+ 			    (char) TOUPPER ((unsigned char) name[0]),
+ 			    (const char*)&name[1]);
+-
+-  fn_name = gfc_get_string ("%s", (const char*)name);
+-
+   sym = NULL;
+   dt_sym = NULL;
+   if (ts->kind != -1)
+     {
+-      /* Look for the derived type and the initializer function. If the type has
+-	 the 'structure' tag, it came from a STRUCTURE keyword, and as such the
+-	 initializer function is obfuscated. */
+-
+-      int find_dt_sym_err = gfc_find_symbol (dt_name, NULL, 0, &dt_sym);
+-      if (dt_sym != NULL && dt_sym->attr.structure)
++      gfc_get_ha_symbol (name, &sym);
++      if (sym->generic && gfc_find_symbol (dt_name, NULL, 0, &dt_sym))
+ 	{
+-	  fn_name = gfc_get_string ("%s_SI", (const char*) name);
+-	  if (gfc_find_symbol(fn_name, NULL, 0, &sym) || sym == NULL) {
+-	    gfc_error ("No initializer was defined for type '%s' at %C", name);
+-	    return MATCH_ERROR;
+-	  }
+-	}
+-      gfc_get_ha_symbol (fn_name, &sym);
+-      if (sym->generic && find_dt_sym_err)
+-	{
+-	  gfc_error ("Type name '%s' at %C is ambiguous", fn_name);
++	  gfc_error ("Type name '%s' at %C is ambiguous", name);
+ 	  return MATCH_ERROR;
+ 	}
+       if (sym->generic && !dt_sym)
+@@ -2932,7 +2901,7 @@ gfc_match_decl_type_spec (gfc_typespec *ts, int implicit_flag)
+     {
+       int iface = gfc_state_stack->previous->state != COMP_INTERFACE
+ 		    || gfc_current_ns->has_import_set;
+-      gfc_find_symbol (fn_name, NULL, iface, &sym);
++      gfc_find_symbol (name, NULL, iface, &sym);
+       if (sym && sym->generic && gfc_find_symbol (dt_name, NULL, 1, &dt_sym))
+ 	{
+ 	  gfc_error ("Type name '%s' at %C is ambiguous", name);
+@@ -6255,13 +6224,8 @@ gfc_match_end (gfc_statement *st)
+   /* Verify that we've got the sort of end-block that we're expecting.  */
+   if (gfc_match (target) != MATCH_YES)
+     {
+-      /* Also accept 'structure' to end types. This isn't an ideal way of doing
+-         this check, but it keeps the delta small. */
+-      if (*st != ST_END_TYPE || gfc_match (" structure") != MATCH_YES)
+-	{
+-	  gfc_error ("Expecting %s statement at %C", gfc_ascii_statement (*st));
+-	  goto cleanup;
+-	}
++      gfc_error ("Expecting %s statement at %C", gfc_ascii_statement (*st));
++      goto cleanup;
+     }
+ 
+   /* If we're at the end, make sure a block name wasn't required.  */
+@@ -7678,7 +7642,7 @@ gfc_get_type_attr_spec (symbol_attribute *attr, char *name)
+    already to be known as a derived type yet have no components.  */
+ 
+ match
+-gfc_match_derived_or_structure_decl (int initializer_flag)
++gfc_match_derived_decl (void)
+ {
+   char name[GFC_MAX_SYMBOL_LEN + 1];
+   char parent[GFC_MAX_SYMBOL_LEN + 1];
+@@ -7689,7 +7653,6 @@ gfc_match_derived_or_structure_decl (int initializer_flag)
+   match is_type_attr_spec = MATCH_NO;
+   bool seen_attr = false;
+   gfc_interface *intr = NULL, *head;
+-  const char* fn_name;
+ 
+   if (gfc_current_state () == COMP_DERIVED)
+     return MATCH_NO;
+@@ -7725,11 +7688,7 @@ gfc_match_derived_or_structure_decl (int initializer_flag)
+ 
+   m = gfc_match (" %n%t", name);
+   if (m != MATCH_YES)
+-    {
+-      m = gfc_match (" /%n/%t", name);
+-      if (m != MATCH_YES)
+-	return m;
+-    }
++    return m;
+ 
+   /* Make sure the name is not the name of an intrinsic type.  */
+   if (gfc_is_intrinsic_typename (name))
+@@ -7739,16 +7698,7 @@ gfc_match_derived_or_structure_decl (int initializer_flag)
+       return MATCH_ERROR;
+     }
+ 
+-  if (initializer_flag)
+-    {
+-      fn_name = name;
+-    }
+-  else
+-    {
+-      fn_name = gfc_get_string ("%s_SI", name);
+-    }
+-
+-  if (gfc_get_symbol (fn_name, NULL, &gensym))
++  if (gfc_get_symbol (name, NULL, &gensym))
+     return MATCH_ERROR;
+ 
+   if (!gensym->attr.generic && gensym->ts.type != BT_UNKNOWN)
+@@ -7779,9 +7729,9 @@ gfc_match_derived_or_structure_decl (int initializer_flag)
+     {
+       /* Use upper case to save the actual derived-type symbol.  */
+       gfc_get_symbol (gfc_get_string ("%c%s",
+-			(char) TOUPPER ((unsigned char) name[0]),
+-			 &name[1]), NULL, &sym);
+-      sym->name = gfc_get_string (name);
++			(char) TOUPPER ((unsigned char) gensym->name[0]),
++			&gensym->name[1]), NULL, &sym);
++      sym->name = gfc_get_string (gensym->name);
+       head = gensym->generic;
+       intr = gfc_get_interface ();
+       intr->sym = sym;
+@@ -7810,10 +7760,6 @@ gfc_match_derived_or_structure_decl (int initializer_flag)
+ 	      == FAILURE)
+     return MATCH_ERROR;
+ 
+-  /* If we specified an initializer, this is a derived type, otherwise it's a
+-     legacy structure */
+-  sym->attr.structure =  initializer_flag ? 0 : 1;
+-
+   if (sym->attr.access != ACCESS_UNKNOWN
+       && gensym->attr.access == ACCESS_UNKNOWN)
+     gensym->attr.access = sym->attr.access;
+@@ -7870,17 +7816,6 @@ gfc_match_derived_or_structure_decl (int initializer_flag)
+   return MATCH_YES;
+ }
+ 
+-match
+-gfc_match_derived_decl (void)
+-{
+-  return gfc_match_derived_or_structure_decl (1);
+-}
+-
+-match
+-gfc_match_structure_decl (void)
+-{
+-  return gfc_match_derived_or_structure_decl (0);
+-}
+ 
+ /* Cray Pointees can be declared as:
+       pointer (ipt, a (n,m,...,*))  */
+diff --git a/gcc/fortran/gfortran.h b/gcc/fortran/gfortran.h
+index 9c6f263..b6cc396 100644
+--- a/gcc/fortran/gfortran.h
++++ b/gcc/fortran/gfortran.h
+@@ -804,7 +804,7 @@ typedef struct
+      entities.  */
+   unsigned alloc_comp:1, pointer_comp:1, proc_pointer_comp:1,
+ 	   private_comp:1, zero_comp:1, coarray_comp:1, lock_comp:1,
+-	   defined_assign_comp:1, unlimited_polymorphic:1, structure:1;
++	   defined_assign_comp:1, unlimited_polymorphic:1;
+ 
+   /* This is a temporary selector for SELECT TYPE or an associate
+      variable for SELECT_TYPE or ASSOCIATE.  */
+diff --git a/gcc/fortran/match.c b/gcc/fortran/match.c
+index c1e4078..9b70574 100644
+--- a/gcc/fortran/match.c
++++ b/gcc/fortran/match.c
+@@ -532,8 +532,8 @@ gfc_match_name (char *buffer)
+   c = gfc_next_ascii_char ();
+   if (!(ISALPHA (c) || (c == '_' && gfc_option.flag_allow_leading_underscore)))
+     {
+-      if (gfc_error_flag_test() == 0 && c != '(' && c != '/')
+-        gfc_error ("Invalid character in name ('%c') at %C",c);
++      if (gfc_error_flag_test() == 0 && c != '(')
++	gfc_error ("Invalid character in name at %C");
+       gfc_current_locus = old_loc;
+       return MATCH_NO;
+     }
+diff --git a/gcc/fortran/match.h b/gcc/fortran/match.h
+index bf751d6..16b1cc9 100644
+--- a/gcc/fortran/match.h
++++ b/gcc/fortran/match.h
+@@ -160,7 +160,6 @@ match gfc_match_function_decl (void);
+ match gfc_match_entry (void);
+ match gfc_match_subroutine (void);
+ match gfc_match_derived_decl (void);
+-match gfc_match_structure_decl (void);
+ match gfc_match_final_decl (void);
+ 
+ match gfc_match_implicit_none (void);
+diff --git a/gcc/fortran/matchexp.c b/gcc/fortran/matchexp.c
+index ab09f48..4643281 100644
+--- a/gcc/fortran/matchexp.c
++++ b/gcc/fortran/matchexp.c
+@@ -32,16 +32,14 @@ static char expression_syntax[] = N_("Syntax error in expression at %C");
+    few restrictions.  The error_flag controls whether an error is
+    raised if 'true' or 'false' are used or not.  */
+ 
+-extern const char* const badops[];
+-
+-const char * const badops[] = {
+-  "and", "or", "not", "eqv", "neqv", "eq", "ne", "ge", "le", "lt", "gt",
+-  NULL
+-};
+-
+ match
+ gfc_match_defined_op_name (char *result, int error_flag)
+ {
++  static const char * const badops[] = {
++    "and", "or", "not", "eqv", "neqv", "eq", "ne", "ge", "le", "lt", "gt",
++      NULL
++  };
++
+   char name[GFC_MAX_SYMBOL_LEN + 1];
+   locus old_loc;
+   match m;
+diff --git a/gcc/fortran/parse.c b/gcc/fortran/parse.c
+index e164a8d..54449e0 100644
+--- a/gcc/fortran/parse.c
++++ b/gcc/fortran/parse.c
+@@ -498,7 +498,6 @@ decode_statement (void)
+       match ("sync all", gfc_match_sync_all, ST_SYNC_ALL);
+       match ("sync images", gfc_match_sync_images, ST_SYNC_IMAGES);
+       match ("sync memory", gfc_match_sync_memory, ST_SYNC_MEMORY);
+-      match ("structure", gfc_match_structure_decl, ST_DERIVED_DECL);
+       break;
+ 
+     case 't':
+diff --git a/gcc/fortran/primary.c b/gcc/fortran/primary.c
+index fa32076..3e18e05 100644
+--- a/gcc/fortran/primary.c
++++ b/gcc/fortran/primary.c
+@@ -30,9 +30,6 @@ along with GCC; see the file COPYING3.  If not see
+ 
+ int matching_actual_arglist = 0;
+ 
+-/* A list of intrinsic operation names from matchexp.c */
+-extern const char* const badops[];
+-
+ /* Matches a kind-parameter expression, which is either a named
+    symbolic constant or a nonnegative integer constant.  If
+    successful, sets the kind value to the correct integer.
+@@ -1848,7 +1845,6 @@ gfc_match_varspec (gfc_expr *primary, int equiv_flag, bool sub_flag,
+   gfc_symbol *sym = primary->symtree->n.sym;
+   match m;
+   bool unknown;
+-  locus old_locus;
+ 
+   tail = NULL;
+ 
+@@ -1946,10 +1942,8 @@ gfc_match_varspec (gfc_expr *primary, int equiv_flag, bool sub_flag,
+       return MATCH_ERROR;
+     }
+ 
+-  old_locus = gfc_current_locus;
+-
+   if ((sym->ts.type != BT_DERIVED && sym->ts.type != BT_CLASS)
+-      || gfc_match_structure_access_operator () != MATCH_YES)
++      || gfc_match_char ('%') != MATCH_YES)
+     goto check_substring;
+ 
+   sym = sym->ts.u.derived;
+@@ -1958,7 +1952,6 @@ gfc_match_varspec (gfc_expr *primary, int equiv_flag, bool sub_flag,
+     {
+       gfc_try t;
+       gfc_symtree *tbp;
+-      int is_operation_name = 0;
+ 
+       m = gfc_match_name (name);
+       if (m == MATCH_NO)
+@@ -2019,21 +2012,6 @@ gfc_match_varspec (gfc_expr *primary, int equiv_flag, bool sub_flag,
+ 	  break;
+ 	}
+ 
+-      /* If this is a reserved name, we should reject this and continue parsing */
+-      for (int i=0; badops[i] != NULL; i++)
+-        {
+-          if (strcmp (name, badops[i])==0)
+-            {
+-              is_operation_name = 1; break;
+-            }
+-        }
+-
+-      if (is_operation_name || gfc_find_uop (name, NULL))
+-        {
+-          gfc_current_locus = old_locus;
+-          break; /* Equivalent to jumping to check_substring */
+-        }
+-
+       component = gfc_find_component (sym, name, false, false);
+       if (component == NULL)
+ 	return MATCH_ERROR;
+-- 
+2.5.0
+

--- a/rhel7/patches/0049-STRUCTURE-UNION-and-MAP-support.patch
+++ b/rhel7/patches/0049-STRUCTURE-UNION-and-MAP-support.patch
@@ -1,0 +1,5825 @@
+From d2efc54556d20c5ce1f4fbfd0226d2194671c4a5 Mon Sep 17 00:00:00 2001
+From: Jim MacArthur <jim.macarthur@codethink.co.uk>
+Date: Tue, 15 Mar 2016 13:59:49 +0000
+Subject: [PATCH 49/55] STRUCTURE, UNION and MAP support.
+
+This work is performed by Fritz Reece <fritzoreese@gmail.com> and is
+a subset of the DEC support patches for GCC 4.8 posted on the GFortran
+mailing list.
+---
+ gcc/fortran/check.c           |    2 +-
+ gcc/fortran/class.c           |   39 +-
+ gcc/fortran/decl.c            |  723 +++++++++++++++++++++----
+ gcc/fortran/dependency.c      |    2 +-
+ gcc/fortran/dump-parse-tree.c |    4 +
+ gcc/fortran/expr.c            |  180 ++++++-
+ gcc/fortran/gfortran.h        |   36 +-
+ gcc/fortran/gfortran.texi     |  231 ++++++--
+ gcc/fortran/interface.c       |  218 ++++++--
+ gcc/fortran/invoke.texi       |   11 +
+ gcc/fortran/lang.opt          |   20 +
+ gcc/fortran/libgfortran.h     |    4 +-
+ gcc/fortran/match.c           |  124 ++++-
+ gcc/fortran/match.h           |    6 +
+ gcc/fortran/misc.c            |    6 +
+ gcc/fortran/module.c          |   47 +-
+ gcc/fortran/options.c         |    8 +
+ gcc/fortran/parse.c           |  552 ++++++++++++++++----
+ gcc/fortran/parse.h           |    6 +
+ gcc/fortran/primary.c         |  122 +++--
+ gcc/fortran/resolve.c         | 1160 +++++++++++++++++++++++------------------
+ gcc/fortran/symbol.c          |  157 +++++-
+ gcc/fortran/target-memory.c   |   12 +-
+ gcc/fortran/trans-decl.c      |   27 +-
+ gcc/fortran/trans-expr.c      |   40 +-
+ gcc/fortran/trans-io.c        |    6 +-
+ gcc/fortran/trans-stmt.c      |    2 +-
+ gcc/fortran/trans-types.c     |   64 ++-
+ gcc/fortran/trans.c           |    4 +-
+ 29 files changed, 2832 insertions(+), 981 deletions(-)
+
+diff --git a/gcc/fortran/check.c b/gcc/fortran/check.c
+index a683216..0f2f1e0 100644
+--- a/gcc/fortran/check.c
++++ b/gcc/fortran/check.c
+@@ -2144,7 +2144,7 @@ gfc_check_kill_sub (gfc_expr *pid, gfc_expr *sig, gfc_expr *status)
+ gfc_try
+ gfc_check_kind (gfc_expr *x)
+ {
+-  if (x->ts.type == BT_DERIVED)
++  if (gfc_bt_struct (x->ts.type) || x->ts.type == BT_CLASS)
+     {
+       gfc_error ("'%s' argument of '%s' intrinsic at %L must be a "
+ 		 "non-derived type", gfc_current_intrinsic_arg[0]->name,
+diff --git a/gcc/fortran/class.c b/gcc/fortran/class.c
+index 55c072b..9841e41 100644
+--- a/gcc/fortran/class.c
++++ b/gcc/fortran/class.c
+@@ -71,12 +71,11 @@ insert_component_ref (gfc_typespec *ts, gfc_ref **ref, const char * const name)
+   gcc_assert (ts->type == BT_DERIVED || ts->type == BT_CLASS);
+   type_sym = ts->u.derived;
+ 
+-  new_ref = gfc_get_ref ();
+-  new_ref->type = REF_COMPONENT;
+-  new_ref->next = *ref;
+-  new_ref->u.c.sym = type_sym;
+-  new_ref->u.c.component = gfc_find_component (type_sym, name, true, true);
++  gfc_find_component (type_sym, name, true, true, &new_ref);
+   gcc_assert (new_ref->u.c.component);
++  while (new_ref->next)
++    new_ref = new_ref->next;
++  new_ref->next = *ref;
+ 
+   if (new_ref->next)
+     {
+@@ -199,8 +198,9 @@ gfc_fix_class_refs (gfc_expr *e)
+ void
+ gfc_add_component_ref (gfc_expr *e, const char *name)
+ {
++  gfc_component *c;
+   gfc_ref **tail = &(e->ref);
+-  gfc_ref *next = NULL;
++  gfc_ref *ref, *next = NULL;
+   gfc_symbol *derived = e->symtree->n.sym->ts.u.derived;
+   while (*tail != NULL)
+     {
+@@ -219,14 +219,13 @@ gfc_add_component_ref (gfc_expr *e, const char *name)
+     }
+   if (*tail != NULL && strcmp (name, "_data") == 0)
+     next = *tail;
+-  (*tail) = gfc_get_ref();
+-  (*tail)->next = next;
+-  (*tail)->type = REF_COMPONENT;
+-  (*tail)->u.c.sym = derived;
+-  (*tail)->u.c.component = gfc_find_component (derived, name, true, true);
+-  gcc_assert((*tail)->u.c.component);
++  c = gfc_find_component (derived, name, true, true, tail);
++  gcc_assert (c);
++  for (ref = *tail; ref->next; ref = ref->next)
++    ;
++  ref->next = next;
+   if (!next)
+-    e->ts = (*tail)->u.c.component->ts;
++    e->ts = c->ts;
+ }
+ 
+ 
+@@ -462,8 +461,7 @@ get_unique_type_string (char *string, gfc_symbol *derived)
+   if (derived->attr.unlimited_polymorphic)
+     strcpy (dt_name, "STAR");
+   else
+-    strcpy (dt_name, derived->name);
+-  dt_name[0] = TOUPPER (dt_name[0]);
++    strcpy (dt_name, gfc_dt_upper_string (derived->name));
+   if (derived->attr.unlimited_polymorphic)
+     sprintf (string, "_%s", dt_name);
+   else if (derived->module)
+@@ -687,7 +685,7 @@ add_proc_comp (gfc_symbol *vtype, const char *name, gfc_typebound_proc *tb)
+   if (tb->non_overridable)
+     return;
+ 
+-  c = gfc_find_component (vtype, name, true, true);
++  c = gfc_find_component (vtype, name, true, true, NULL);
+ 
+   if (c == NULL)
+     {
+@@ -754,7 +752,7 @@ copy_vtab_proc_comps (gfc_symbol *declared, gfc_symbol *vtype)
+ 
+   for (cmp = vtab->ts.u.derived->components; cmp; cmp = cmp->next)
+     {
+-      if (gfc_find_component (vtype, cmp->name, true, true))
++      if (gfc_find_component (vtype, cmp->name, true, true, NULL))
+ 	continue;
+ 
+       add_proc_comp (vtype, cmp->name, cmp->tb);
+@@ -2300,7 +2298,8 @@ gfc_find_derived_vtab (gfc_symbol *derived)
+ 		  gfc_set_sym_referenced (def_init);
+ 		  def_init->ts.type = BT_DERIVED;
+ 		  def_init->ts.u.derived = derived;
+-		  def_init->value = gfc_default_initializer (&def_init->ts);
++		  def_init->value = gfc_default_initializer (&def_init->ts,
++                                                             false);
+ 
+ 		  c->initializer = gfc_lval_expr_from_sym (def_init);
+ 		}
+@@ -2392,7 +2391,7 @@ gfc_find_derived_vtab (gfc_symbol *derived)
+ 
+ have_vtype:
+ 	  vtab->ts.u.derived = vtype;
+-	  vtab->value = gfc_default_initializer (&vtab->ts);
++	  vtab->value = gfc_default_initializer (&vtab->ts, false);
+ 	}
+     }
+ 
+@@ -2666,7 +2665,7 @@ gfc_find_intrinsic_vtab (gfc_typespec *ts)
+ 	      c->initializer = gfc_get_null_expr (NULL);
+ 	    }
+ 	  vtab->ts.u.derived = vtype;
+-	  vtab->value = gfc_default_initializer (&vtab->ts);
++	  vtab->value = gfc_default_initializer (&vtab->ts, false);
+ 	}
+     }
+ 
+diff --git a/gcc/fortran/decl.c b/gcc/fortran/decl.c
+index 8ff7bca..4fb8e26 100644
+--- a/gcc/fortran/decl.c
++++ b/gcc/fortran/decl.c
+@@ -53,6 +53,7 @@ static gfc_typespec current_ts;
+ static symbol_attribute current_attr;
+ static gfc_array_spec *current_as;
+ static int colon_seen;
++static int attr_seen;
+ 
+ /* The current binding label (if any).  */
+ static const char* curr_binding_label;
+@@ -377,13 +378,13 @@ match_data_constant (gfc_expr **result)
+ 
+   if (sym == NULL
+       || (sym->attr.flavor != FL_PARAMETER
+-	  && (!dt_sym || dt_sym->attr.flavor != FL_DERIVED)))
++	  && (!dt_sym || !gfc_fl_struct (dt_sym->attr.flavor))))
+     {
+       gfc_error ("Symbol '%s' must be a PARAMETER in DATA statement at %C",
+ 		 name);
+       return MATCH_ERROR;
+     }
+-  else if (dt_sym && dt_sym->attr.flavor == FL_DERIVED)
++  else if (dt_sym && gfc_fl_struct (dt_sym->attr.flavor))
+     return gfc_match_structure_constructor (dt_sym, result);
+ 
+   /* Check to see if the value is an initialization array expression.  */
+@@ -582,6 +583,147 @@ cleanup:
+ 
+ /************************ Declaration statements *********************/
+ 
++/* Like gfc_match_init_expr, but matches a 'clist' (old-style initialization
++   list). The difference here is the expression is a list of constants
++   and is surrounded by '/'. 
++   The typespec ts must match the typespec of the variable which the
++   clist is initializing.
++   The scalar parameter tells whether this should match a scalar
++   initialization or a list of constants corresponding to array elements. */
++match
++gfc_match_clist_expr (gfc_expr **result, gfc_typespec *ts, gfc_array_spec *as)
++{
++  gfc_constructor_base array_head = NULL;
++  gfc_expr *expr = NULL;
++  match m;
++  locus where;
++  mpz_t repeat, size;
++  bool scalar;
++  int cmp;
++
++  gcc_assert (ts);
++
++  mpz_init_set_ui (repeat, 0);
++  mpz_init (size);
++  scalar = !as || !as->rank;
++
++  /* We have already matched "/". Now look for a constant list, as with
++     top_val_list from decl.c, but append the result to an array constructor. */
++  if (gfc_match ("/") == MATCH_YES)
++  {
++    gfc_error ("Empty old style initializer list at %C");
++    goto cleanup;
++  }
++
++  where = gfc_current_locus;
++  for (;;)
++    {
++      m = match_data_constant (&expr);
++      if (m == MATCH_NO)
++        goto syntax;
++      if (m == MATCH_ERROR)
++        goto cleanup;
++
++      /* Found a repeat specification; match again the actual constant. */
++      if (expr->ts.type == BT_INTEGER && gfc_match_char ('*') == MATCH_YES)
++      {
++        if (scalar)
++        {
++          gfc_error ("Invalid scalar initializer at %C");
++          goto cleanup;
++        }
++        mpz_set (repeat, expr->value.integer);
++        gfc_free_expr (expr);
++        expr = NULL;
++
++        m = match_data_constant (&expr);
++        if (m == MATCH_NO)
++          goto syntax;
++        if (m == MATCH_ERROR)
++          goto cleanup;
++      }
++      else
++        mpz_set_ui (repeat, 1);
++
++      if (!scalar)
++      {
++        /* Add the constant initializer as many times as repeated. */
++        for (; mpz_cmp_ui (repeat, 0) > 0; mpz_sub_ui (repeat, repeat, 1))
++        {
++          /* Make sure types of elements match */
++          if(ts && !gfc_compare_types (&expr->ts, ts)
++                && gfc_convert_type (expr, ts, 1) == FAILURE)
++            goto cleanup;
++
++          gfc_constructor_append_expr (&array_head,
++              gfc_copy_expr (expr), &gfc_current_locus);
++        }
++
++        gfc_free_expr (expr);
++      }
++      /* For scalar initializers quit after one element. */
++      else
++      {
++        if(gfc_match_char ('/') != MATCH_YES)
++        {
++          gfc_error ("End of scalar initializer expected at %C");
++          goto cleanup;
++        }
++        break;
++      }
++
++      if (gfc_match_char ('/') == MATCH_YES)
++        break;
++      if (gfc_match_char (',') == MATCH_NO)
++        goto syntax;
++    }
++
++  /* Set up expr as an array constructor. */
++  if (!scalar)
++  {
++    expr = gfc_get_array_expr (ts->type, ts->kind, &where);
++    expr->ts = *ts;
++    expr->value.constructor = array_head;
++
++    expr->rank = as->rank;
++    expr->shape = gfc_get_shape (expr->rank);
++
++    /* Validate sizes. */
++    gcc_assert (gfc_array_size (expr, &size) == SUCCESS);
++    gcc_assert (spec_size (as, &repeat) == SUCCESS);
++    cmp = mpz_cmp (size, repeat);
++    if (cmp < 0)
++      gfc_error ("Not enough elements in array initializer at %C");
++    else if (cmp > 0)
++      gfc_error ("Too many elements in array initializer at %C");
++    if (cmp)
++      goto cleanup;
++  }
++
++  /* Make sure scalar types match. */
++  else if (!gfc_compare_types (&expr->ts, ts)
++           && gfc_convert_type (expr, ts, 1) == FAILURE)
++    goto cleanup;
++
++  if (expr->ts.u.cl)
++    expr->ts.u.cl->length_from_typespec = 1;
++
++  *result = expr;
++  mpz_clear (size);
++  mpz_clear (repeat);
++  return MATCH_YES;
++
++syntax:
++  gfc_error ("Syntax error in old style initializer list at %C");
++
++cleanup:
++  gfc_constructor_free (array_head);
++  expr->value.constructor = NULL;
++  gfc_free_expr (expr);
++  mpz_clear (size);
++  mpz_clear (repeat);
++  return MATCH_ERROR;
++}
+ 
+ /* Auxiliary function to merge DIMENSION and CODIMENSION array specs.  */
+ 
+@@ -1362,7 +1504,7 @@ add_init_expr_to_sym (const char *name, gfc_expr **initp, locus *var_locus)
+ 
+       /* Check if the assignment can happen. This has to be put off
+ 	 until later for derived type variables and procedure pointers.  */
+-      if (sym->ts.type != BT_DERIVED && init->ts.type != BT_DERIVED
++      if (!gfc_bt_struct (sym->ts.type) && !gfc_bt_struct (init->ts.type)
+ 	  && sym->ts.type != BT_CLASS && init->ts.type != BT_CLASS
+ 	  && !sym->attr.proc_pointer
+ 	  && gfc_check_assign_symbol (sym, NULL, init) == FAILURE)
+@@ -1482,7 +1624,7 @@ add_init_expr_to_sym (const char *name, gfc_expr **initp, locus *var_locus)
+ 	 If we mark my_int as iso_c (since we can see it's value
+ 	 is equal to one of the named constants), then my_int_2
+ 	 will be considered C interoperable.  */
+-      if (sym->ts.type != BT_CHARACTER && sym->ts.type != BT_DERIVED)
++      if (sym->ts.type != BT_CHARACTER && !gfc_bt_struct (sym->ts.type))
+ 	{
+ 	  sym->ts.is_iso_c |= init->ts.is_iso_c;
+ 	  sym->ts.is_c_interop |= init->ts.is_c_interop;
+@@ -1540,6 +1682,7 @@ static gfc_try
+ build_struct (const char *name, gfc_charlen *cl, gfc_expr **init,
+ 	      gfc_array_spec **as)
+ {
++  gfc_state_data *s;
+   gfc_component *c;
+   gfc_try t = SUCCESS;
+ 
+@@ -1563,6 +1706,32 @@ build_struct (const char *name, gfc_charlen *cl, gfc_expr **init,
+ 	}
+     }
+ 
++  /* If we are in a nested union/map definition, gfc_add_component will not
++     properly find repeated components because they are implicitly chained.
++     Since union and map blocks are not actually linked as components of their
++     parent structures until after they are parsed, we must traverse up the
++     parse stack until we find the top level structure declaration, searching
++     for the component in each block along the way. */
++  s = gfc_state_stack;
++  if (s->state == COMP_UNION || s->state == COMP_MAP)
++  {
++    while (s->state == COMP_UNION || s->state == COMP_MAP
++           || gfc_comp_is_derived (s->state))
++    {
++      c = gfc_find_component (s->sym, name, true, true, NULL);
++      if (c != NULL)
++      {
++        gfc_error_now ("Component '%s' at %C already declared at %L",
++                       name, &c->loc);
++        return FAILURE;
++      }
++      /* Break after we've searched the ultimate parent of the current union. */
++      if (s->state == COMP_DERIVED || s->state == COMP_STRUCTURE)
++        break;
++      s = s->previous;
++    }
++  }
++
+   if (gfc_add_component (gfc_current_block (), name, &c) == FAILURE)
+     return FAILURE;
+ 
+@@ -1584,51 +1753,7 @@ build_struct (const char *name, gfc_charlen *cl, gfc_expr **init,
+     }
+   *as = NULL;
+ 
+-  /* Should this ever get more complicated, combine with similar section
+-     in add_init_expr_to_sym into a separate function.  */
+-  if (c->ts.type == BT_CHARACTER && !c->attr.pointer && c->initializer
+-      && c->ts.u.cl
+-      && c->ts.u.cl->length && c->ts.u.cl->length->expr_type == EXPR_CONSTANT)
+-    {
+-      int len;
+-
+-      gcc_assert (c->ts.u.cl && c->ts.u.cl->length);
+-      gcc_assert (c->ts.u.cl->length->expr_type == EXPR_CONSTANT);
+-      gcc_assert (c->ts.u.cl->length->ts.type == BT_INTEGER);
+-
+-      len = mpz_get_si (c->ts.u.cl->length->value.integer);
+-
+-      if (c->initializer->expr_type == EXPR_CONSTANT)
+-	gfc_set_constant_character_len (len, c->initializer, -1);
+-      else if (mpz_cmp (c->ts.u.cl->length->value.integer,
+-			c->initializer->ts.u.cl->length->value.integer))
+-	{
+-	  gfc_constructor *ctor;
+-	  ctor = gfc_constructor_first (c->initializer->value.constructor);
+-
+-	  if (ctor)
+-	    {
+-	      int first_len;
+-	      bool has_ts = (c->initializer->ts.u.cl
+-			     && c->initializer->ts.u.cl->length_from_typespec);
+-
+-	      /* Remember the length of the first element for checking
+-		 that all elements *in the constructor* have the same
+-		 length.  This need not be the length of the LHS!  */
+-	      gcc_assert (ctor->expr->expr_type == EXPR_CONSTANT);
+-	      gcc_assert (ctor->expr->ts.type == BT_CHARACTER);
+-	      first_len = ctor->expr->value.character.length;
+-
+-	      for ( ; ctor; ctor = gfc_constructor_next (ctor))
+-		if (ctor->expr->expr_type == EXPR_CONSTANT)
+-		{
+-		  gfc_set_constant_character_len (len, ctor->expr,
+-						  has_ts ? -1 : first_len);
+-		  ctor->expr->ts.u.cl->length = gfc_copy_expr (c->ts.u.cl->length);
+-		}
+-	    }
+-	}
+-    }
++  gfc_apply_init (&c->ts, &c->attr, c->initializer);
+ 
+   /* Check array components.  */
+   if (!c->attr.dimension)
+@@ -1745,7 +1870,7 @@ match_pointer_init (gfc_expr **init, int procptr)
+ {
+   match m;
+ 
+-  if (gfc_pure (NULL) && gfc_state_stack->state != COMP_DERIVED)
++  if (gfc_pure (NULL) && !gfc_comp_is_derived(gfc_state_stack->state))
+     {
+       gfc_error ("Initialization of pointer at %C is not allowed in "
+ 		 "a PURE procedure");
+@@ -1845,7 +1970,8 @@ static match
+ variable_decl (int elem)
+ {
+   char name[GFC_MAX_SYMBOL_LEN + 1];
+-  gfc_expr *initializer;
++  static int fill_id = 0;
++  gfc_expr *initializer, *char_len;
+   gfc_array_spec *as;
+   gfc_array_spec *cp_as; /* Extra copy for Cray Pointees.  */
+   gfc_charlen *cl;
+@@ -1866,9 +1992,44 @@ variable_decl (int elem)
+   /* When we get here, we've just matched a list of attributes and
+      maybe a type and a double colon.  The next thing we expect to see
+      is the name of the symbol.  */
+-  m = gfc_match_name (name);
++
++  /* If we are parsing a structure, we allow the name of the symbol to
++     be '%FILL', which gives it an anonymous (inaccessible) name. */
++  m = MATCH_NO;
++  gfc_gobble_whitespace ();
++  if (gfc_peek_ascii_char () == '%')
++  {
++    gfc_next_ascii_char ();
++    m = gfc_match ("fill");
++  }
+   if (m != MATCH_YES)
+-    goto cleanup;
++  {
++    m = gfc_match_name (name);
++    if (m != MATCH_YES)
++      goto cleanup;
++  }
++  else 
++  {
++    m = MATCH_ERROR;
++    if (!gfc_option.flag_dec_structure)
++    {
++      gfc_error ("%%FILL at %C is an extension, enable with -fdec-structure");
++      goto cleanup;
++    }
++    if (gfc_current_state () != COMP_STRUCTURE)
++    {
++      gfc_error ("Unnamed field at %C only allowed in a STRUCTURE block");
++      goto cleanup;
++    }
++    if (attr_seen)
++    {
++      gfc_error ("Unnamed field at %C may not have attributes");
++      goto cleanup;
++    }
++    /* The unique anonymous name is an invalid fortran identifier. */
++    sprintf (name, "%%FILL%d", fill_id++);
++    m = MATCH_YES;
++  }
+ 
+   var_locus = gfc_current_locus;
+ 
+@@ -1947,10 +2108,19 @@ variable_decl (int elem)
+ 	goto cleanup;
+     }
+ 
++  /* Fill components may not have initializers. */
++  if (name[0] == '%' && gfc_match_eos () != MATCH_YES) 
++  {
++    gfc_error ("Unnamed field at %C may not have initializers");
++    m = MATCH_ERROR;
++    goto cleanup;
++  }
++
+   /*  If this symbol has already shown up in a Cray Pointer declaration,
+       and this is not a component declaration,
+       then we want to set the type & bail out.  */
+-  if (gfc_option.flag_cray_pointer && gfc_current_state () != COMP_DERIVED)
++  if (gfc_option.flag_cray_pointer
++      && !gfc_comp_is_derived (gfc_current_state ()))
+     {
+       gfc_find_symbol (name, gfc_current_ns, 1, &sym);
+       if (sym != NULL && sym->attr.cray_pointee)
+@@ -2014,7 +2185,7 @@ variable_decl (int elem)
+      For components of derived types, it is not true, so we don't
+      create a symbol for those yet.  If we fail to create the symbol,
+      bail out.  */
+-  if (gfc_current_state () != COMP_DERIVED
++  if (!gfc_comp_is_derived (gfc_current_state ())
+       && build_sym (name, cl, cl_deferred, &as, &var_locus) == FAILURE)
+     {
+       m = MATCH_ERROR;
+@@ -2051,35 +2222,30 @@ variable_decl (int elem)
+ 
+       else if (gfc_current_state () == COMP_DERIVED)
+ 	{
+-	  if(!(gfc_option.allow_std & GFC_STD_EXTRA_LEGACY))
+-	    {
+-	      gfc_error ("Invalid old style initialization for derived type "
+-			 "component at %C");
+-	      m = MATCH_ERROR;
+-	      goto cleanup;
+-	    }
+-	  else
+-	    {
+-	      /* Attempt to match an old-style initializer which is a simple
+-		 integer or character expression; this will not work with
+-		 multiple values. */
+-	      m = gfc_match_init_expr (&initializer);
+-	      if (m == MATCH_ERROR)
+-		goto cleanup;
+-	      else if (m == MATCH_YES)
+-		{
+-		  m = gfc_match ("/");
+-		  if (m != MATCH_YES)
+-		    goto cleanup;
+-		}
+-	    }
++	  gfc_error ("Invalid old style initialization for derived type "
++		     "component at %C");
++	  m = MATCH_ERROR;
++	  goto cleanup;
++	}
++      /* For derived type components, read the initializer as a special
++         expression and let the rest of this function apply the initializer
++         as usual. */
++      else if (gfc_comp_is_derived (gfc_current_state ()))
++	{
++	  m = gfc_match_clist_expr (&initializer, &current_ts, as);
++	  if (m == MATCH_NO)
++	    gfc_error ("Syntax error in old style initialization of "
++		       "structure component %s at %C", name);
++	  if (m != MATCH_YES)
++	    goto cleanup;
+ 	}
++
++      /* Otherwise we treat the old style initialization just like a
++         DATA declaration for the current variable. */
+       else
+         return match_old_style_init (name);
+-
+     }
+-
+-
++  
+   /* The double colon must be present in order to have initializers.
+      Otherwise the statement is ambiguous with an assignment statement.  */
+   if (colon_seen)
+@@ -2115,7 +2281,7 @@ variable_decl (int elem)
+ 	    }
+ 
+ 	  if (current_attr.flavor != FL_PARAMETER && gfc_pure (NULL)
+-	      && gfc_state_stack->state != COMP_DERIVED)
++	      && !gfc_comp_is_derived (gfc_state_stack->state))
+ 	    {
+ 	      gfc_error ("Initialization of variable at %C is not allowed in "
+ 			 "a PURE procedure");
+@@ -2123,7 +2289,7 @@ variable_decl (int elem)
+ 	    }
+ 
+ 	  if (current_attr.flavor != FL_PARAMETER
+-	      && gfc_state_stack->state != COMP_DERIVED)
++	      && !gfc_comp_is_derived(gfc_state_stack->state))
+ 	    gfc_unset_implicit_pure (gfc_current_ns->proc_name);
+ 
+ 	  if (m != MATCH_YES)
+@@ -2132,7 +2298,7 @@ variable_decl (int elem)
+     }
+ 
+   if (initializer != NULL && current_attr.allocatable
+-	&& gfc_current_state () == COMP_DERIVED)
++	&& gfc_comp_is_derived (gfc_current_state ()))
+     {
+       gfc_error ("Initialization of allocatable component at %C is not "
+ 		 "allowed");
+@@ -2143,14 +2309,20 @@ variable_decl (int elem)
+   /* Add the initializer.  Note that it is fine if initializer is
+      NULL here, because we sometimes also need to check if a
+      declaration *must* have an initialization expression.  */
+-  if (gfc_current_state () != COMP_DERIVED)
++  if (!gfc_comp_is_derived (gfc_current_state ()))
+     t = add_init_expr_to_sym (name, &initializer, &var_locus);
+   else
+     {
+       if (current_ts.type == BT_DERIVED
+ 	  && !current_attr.pointer && !initializer)
+-	initializer = gfc_default_initializer (&current_ts);
++	initializer = gfc_default_initializer (&current_ts, false);
+       t = build_struct (name, cl, &initializer, &as);
++
++      /* If we match a nested structure definition we expect to see the
++         body even if the component declarations blow up, so we need to keep
++         the structure type around.  */
++      if (gfc_new_block && gfc_new_block->attr.flavor == FL_STRUCT)
++        gfc_commit_symbol (gfc_new_block);
+     }
+ 
+   m = (t == SUCCESS) ? MATCH_YES : MATCH_ERROR;
+@@ -2637,6 +2809,35 @@ done:
+   return MATCH_YES;
+ }
+ 
++/* Matches a RECORD declaration. */
++
++static match
++match_record_decl(const char *name)
++{
++    locus old_loc;
++    old_loc = gfc_current_locus;
++
++    if (gfc_match (" record") == MATCH_YES)
++    {
++        if (!gfc_option.flag_dec_structure)
++        {
++            gfc_current_locus = old_loc;
++            gfc_error ("RECORD at %C is a DEC extension, enable with "
++                       "-fdec-structure");
++            return MATCH_ERROR;
++        }
++        if (gfc_match (" /%n/", name) != MATCH_YES)
++        {
++            gfc_error ("Expected \"/field-name/\" after RECORD at %C");
++            gfc_current_locus = old_loc;
++            return MATCH_ERROR;
++        }
++        return MATCH_YES;
++    }
++
++    gfc_current_locus = old_loc;
++    return MATCH_NO;
++}
+ 
+ /* Matches a declaration-type-spec (F03:R502).  If successful, sets the ts
+    structure to the matched specification.  This is necessary for FUNCTION and
+@@ -2696,7 +2897,7 @@ gfc_match_decl_type_spec (gfc_typespec *ts, int implicit_flag)
+ 	{
+ 	  if ((m = gfc_match ("*)")) != MATCH_YES)
+ 	    return m;
+-	  if (gfc_current_state () == COMP_DERIVED)
++	  if (gfc_comp_is_derived (gfc_current_state ()))
+ 	    {
+ 	      gfc_error ("Assumed type at %C is not allowed for components");
+ 	      return MATCH_ERROR;
+@@ -2809,9 +3010,57 @@ gfc_match_decl_type_spec (gfc_typespec *ts, int implicit_flag)
+     m = gfc_match_char (')');
+ 
+   if (m == MATCH_YES)
++  {
+     ts->type = BT_DERIVED;
++    /* Don't need all the extra derived-type stuff for structures. */
++    if (gfc_find_symbol (gfc_dt_upper_string (name), NULL, 1, &sym))
++    {
++      gfc_error ("Type name '%s' at %C is ambiguous", name);
++      return MATCH_ERROR;
++    }
++    if (sym && sym->attr.flavor == FL_STRUCT)
++    {
++      ts->u.derived = sym;
++      return MATCH_YES;
++    }
++  }
+   else
+     {
++      /* Match RECORD declarations. */
++      m = match_record_decl (name);
++      if (m == MATCH_YES)
++      {
++        ts->type = BT_DERIVED;
++        /* Don't need all the extra derived-type stuff for structures. */
++        if (gfc_find_symbol (gfc_dt_upper_string (name), NULL, 1, &sym))
++        {
++          gfc_error ("Type name '%s' at %C is ambiguous", name);
++          return MATCH_ERROR;
++        }
++        if (sym && sym->attr.flavor == FL_STRUCT)
++        {
++          ts->u.derived = sym;
++          return MATCH_YES;
++        }
++        goto derived;
++      }
++
++      /* Match ad-hoc STRUCTURE declarations; only valid within another
++         derived/structure declaration. */
++      m = gfc_match (" structure");
++      if (m == MATCH_YES && gfc_comp_is_derived (gfc_current_state ()))
++      {
++        m = gfc_match_structure_decl ();
++        if (m == MATCH_YES)
++        {
++          /* gfc_new_block updated by match_structure_decl() */
++          ts->type = BT_DERIVED;
++          ts->u.derived = gfc_new_block;
++          return MATCH_YES;
++        }
++        return MATCH_ERROR;
++      }
++
+       /* Match CLASS declarations.  */
+       m = gfc_match (" class ( * )");
+       if (m == MATCH_ERROR)
+@@ -2860,6 +3109,7 @@ gfc_match_decl_type_spec (gfc_typespec *ts, int implicit_flag)
+ 	return MATCH_ERROR;
+     }
+ 
++derived:
+   /* Defer association of the derived type until the end of the
+      specification block.  However, if the derived type can be
+      found, add it to the typespec.  */
+@@ -2881,9 +3131,7 @@ gfc_match_decl_type_spec (gfc_typespec *ts, int implicit_flag)
+      stored in a symtree with the first letter of the name capitalized; the
+      symtree with the all lower-case name contains the associated
+      generic function.  */
+-  dt_name = gfc_get_string ("%c%s",
+-			    (char) TOUPPER ((unsigned char) name[0]),
+-			    (const char*)&name[1]);
++  dt_name = gfc_dt_upper_string (name);
+   sym = NULL;
+   dt_sym = NULL;
+   if (ts->kind != -1)
+@@ -2915,7 +3163,7 @@ gfc_match_decl_type_spec (gfc_typespec *ts, int implicit_flag)
+ 	return MATCH_NO;
+     }
+ 
+-  if ((sym->attr.flavor != FL_UNKNOWN
++  if ((sym->attr.flavor != FL_UNKNOWN && sym->attr.flavor != FL_STRUCT
+        && !(sym->attr.flavor == FL_PROCEDURE && sym->attr.generic))
+       || sym->attr.subroutine)
+     {
+@@ -2955,9 +3203,8 @@ gfc_match_decl_type_spec (gfc_typespec *ts, int implicit_flag)
+ 
+   gfc_set_sym_referenced (dt_sym);
+ 
+-  if (dt_sym->attr.flavor != FL_DERIVED
+-      && gfc_add_flavor (&dt_sym->attr, FL_DERIVED, sym->name, NULL)
+-			 == FAILURE)
++  if (dt_sym->attr.flavor != FL_DERIVED && dt_sym->attr.flavor != FL_STRUCT
++      && gfc_add_flavor (&dt_sym->attr, FL_DERIVED, sym->name, NULL) == FAILURE)
+     return MATCH_ERROR;
+ 
+   ts->u.derived = dt_sym;
+@@ -3318,9 +3565,7 @@ gfc_match_import (void)
+ 		 letter of the name capitalized; the symtree with the all
+ 		 lower-case name contains the associated generic function. */
+ 	      st = gfc_new_symtree (&gfc_current_ns->sym_root,
+-			gfc_get_string ("%c%s",
+-				(char) TOUPPER ((unsigned char) name[0]),
+-				&name[1]));
++                                    gfc_dt_upper_string (name));
+ 	      st->n.sym = sym;
+ 	      sym->refs++;
+ 	      sym->attr.imported = 1;
+@@ -3404,6 +3649,7 @@ match_attr_spec (void)
+ 
+   current_as = NULL;
+   colon_seen = 0;
++  attr_seen = 0;
+ 
+   /* See if we get all of the keywords up to the final double colon.  */
+   for (d = GFC_DECL_BEGIN; d != GFC_DECL_END; d++)
+@@ -3751,8 +3997,10 @@ match_attr_spec (void)
+     {
+       if (seen[d] == 0)
+ 	continue;
++      else
++        attr_seen = 1;
+ 
+-      if (gfc_current_state () == COMP_DERIVED
++      if (gfc_comp_is_derived (gfc_current_state ())
+ 	  && d != DECL_DIMENSION && d != DECL_CODIMENSION
+ 	  && d != DECL_POINTER   && d != DECL_PRIVATE
+ 	  && d != DECL_PUBLIC && d != DECL_CONTIGUOUS && d != DECL_NONE)
+@@ -3760,7 +4008,8 @@ match_attr_spec (void)
+ 	  if (d == DECL_ALLOCATABLE)
+ 	    {
+ 	      if (gfc_notify_std (GFC_STD_F2003, "ALLOCATABLE "
+-				  "attribute at %C in a TYPE definition")
++				  "attribute at %C in a %s definition",
++                                  gfc_ascii_comp_state(gfc_current_state()))
+ 		  == FAILURE)
+ 		{
+ 		  m = MATCH_ERROR;
+@@ -3769,8 +4018,8 @@ match_attr_spec (void)
+ 	    }
+ 	  else
+ 	    {
+-	      gfc_error ("Attribute at %L is not allowed in a TYPE definition",
+-			 &seen_at[d]);
++	      gfc_error ("Attribute at %L is not allowed in a %s definition",
++			&seen_at[d], gfc_ascii_comp_state(gfc_current_state()));
+ 	      m = MATCH_ERROR;
+ 	      goto cleanup;
+ 	    }
+@@ -3783,13 +4032,14 @@ match_attr_spec (void)
+ 	    attr = "PRIVATE";
+ 	  else
+ 	    attr = "PUBLIC";
+-	  if (gfc_current_state () == COMP_DERIVED
++	  if (gfc_comp_is_derived (gfc_current_state ())
+ 	      && gfc_state_stack->previous
+ 	      && gfc_state_stack->previous->state == COMP_MODULE)
+ 	    {
+ 	      if (gfc_notify_std (GFC_STD_F2003, "Attribute %s "
+-				  "at %L in a TYPE definition", attr,
+-				  &seen_at[d])
++				  "at %L in a %s definition", attr,
++				  &seen_at[d],
++                                  gfc_ascii_comp_state(gfc_current_state()))
+ 		  == FAILURE)
+ 		{
+ 		  m = MATCH_ERROR;
+@@ -3953,6 +4203,7 @@ cleanup:
+   gfc_current_locus = start;
+   gfc_free_array_spec (current_as);
+   current_as = NULL;
++  attr_seen = 0;
+   return m;
+ }
+ 
+@@ -4005,7 +4256,7 @@ set_com_block_bind_c (gfc_common_head *com_block, int is_bind_c)
+ gfc_try
+ gfc_verify_c_interop (gfc_typespec *ts)
+ {
+-  if (ts->type == BT_DERIVED && ts->u.derived != NULL)
++  if (gfc_bt_struct (ts->type) && ts->u.derived != NULL)
+     return (ts->u.derived->ts.is_c_interop || ts->u.derived->attr.is_bind_c)
+ 	   ? SUCCESS : FAILURE;
+   else if (ts->type == BT_CLASS)
+@@ -4095,7 +4346,8 @@ verify_bind_c_sym (gfc_symbol *tmp_sym, gfc_typespec *ts,
+ 	    }
+ 	  else
+ 	    {
+-              if (tmp_sym->ts.type == BT_DERIVED || ts->type == BT_DERIVED)
++              if (gfc_bt_struct (tmp_sym->ts.type) 
++                  || gfc_bt_struct (ts->type))
+                 gfc_error ("Type declaration '%s' at %L is not C "
+                            "interoperable but it is BIND(C)",
+                            tmp_sym->name, &(tmp_sym->declared_at));
+@@ -4357,7 +4609,7 @@ gfc_match_data_decl (void)
+     return m;
+ 
+   if ((current_ts.type == BT_DERIVED || current_ts.type == BT_CLASS)
+-	&& gfc_current_state () != COMP_DERIVED)
++	&& !gfc_comp_is_derived(gfc_current_state ()))
+     {
+       sym = gfc_use_derived (current_ts.u.derived);
+ 
+@@ -4386,7 +4638,7 @@ gfc_match_data_decl (void)
+       && !current_ts.u.derived->attr.zero_comp)
+     {
+ 
+-      if (current_attr.pointer && gfc_current_state () == COMP_DERIVED)
++      if (current_attr.pointer && gfc_comp_is_derived (gfc_current_state ()))
+ 	goto ok;
+ 
+       gfc_find_symbol (current_ts.u.derived->name,
+@@ -4394,9 +4646,10 @@ gfc_match_data_decl (void)
+ 
+       /* Any symbol that we find had better be a type definition
+ 	 which has its components defined.  */
+-      if (sym != NULL && sym->attr.flavor == FL_DERIVED
++      if (sym != NULL && gfc_fl_struct (sym->attr.flavor)
+ 	  && (current_ts.u.derived->components != NULL
+-	      || current_ts.u.derived->attr.zero_comp))
++	      || current_ts.u.derived->attr.zero_comp
++              || current_ts.u.derived == gfc_new_block))
+ 	goto ok;
+ 
+       /* Now we have an error, which we signal, and then fix up
+@@ -5298,6 +5551,7 @@ gfc_match_procedure (void)
+     case COMP_INTERFACE:
+       m = match_procedure_in_interface ();
+       break;
++    case COMP_STRUCTURE:
+     case COMP_DERIVED:
+       m = match_ppc_decl ();
+       break;
+@@ -5545,6 +5799,10 @@ gfc_match_entry (void)
+ 	    gfc_error ("ENTRY statement at %C cannot appear within "
+ 		       "an INTERFACE");
+ 	    break;
++          case COMP_STRUCTURE:
++            gfc_error ("ENTRY statement at %C cannot appear within "
++                       "a STRUCTURE block");
++            break;
+ 	  case COMP_DERIVED:
+ 	    gfc_error ("ENTRY statement at %C cannot appear within "
+ 		       "a DERIVED TYPE block");
+@@ -6130,6 +6388,24 @@ gfc_match_end (gfc_statement *st)
+       eos_ok = 0;
+       break;
+ 
++    case COMP_MAP:
++      *st = ST_END_MAP;
++      target = " map";
++      eos_ok = 0;
++      break;
++
++    case COMP_UNION:
++      *st = ST_END_UNION;
++      target = " union";
++      eos_ok = 0;
++      break;
++
++    case COMP_STRUCTURE:
++      *st = ST_END_STRUCTURE;
++      target = " structure";
++      eos_ok = 0;
++      break;
++
+     case COMP_DERIVED:
+     case COMP_DERIVED_CONTAINS:
+       *st = ST_END_TYPE;
+@@ -7636,6 +7912,216 @@ gfc_get_type_attr_spec (symbol_attribute *attr, char *name)
+   return MATCH_YES;
+ }
+ 
++/* Common function for type declaration blocks similar to derived types, such
++   as STRUCTURES and MAPs. Unlike derived types, a structure type
++   does NOT have a generic symbol matching the name given by the user.
++   STRUCTUREs can share names with variables and PARAMETERs so we must allow
++   for the creation of an independent symbol.
++   Other parameters are a message to prefix errors with, the name of the new 
++   type to be created, and the flavor to add to the resulting symbol. */
++
++static gfc_try
++get_struct_decl (const char *name, sym_flavor fl, locus *decl,
++                 gfc_symbol **result)
++{
++  gfc_symbol *sym;
++  locus where;
++
++  if (decl)
++    where = *decl;
++  else
++    where = gfc_current_locus;
++
++  if (gfc_get_symbol (name, NULL, &sym))
++    return FAILURE;
++
++  sym->declared_at = where;
++
++  gcc_assert (name[0] == (char) TOUPPER (name[0]));
++
++  if (sym && (sym->components != NULL || sym->attr.zero_comp))
++  {
++    gfc_error ("Type definition of '%s' at %C was already defined at %L", 
++               sym->name, &sym->declared_at);
++    return FAILURE;
++  }
++
++  if (!sym)
++  {
++    gfc_internal_error ("Failed to create structure type '%s' at %C", name);
++    return FAILURE;
++  }
++
++  if (sym->attr.flavor != fl
++      && gfc_add_flavor (&sym->attr, fl, sym->name, NULL) == FAILURE)
++    return FAILURE;
++
++  if (!sym->hash_value)
++      /* Set the hash for the compound name for this type.  */
++    sym->hash_value = gfc_hash_value (sym);
++
++  /* Normally the type is expected to have been completely parsed by the time
++     a field declaration with this type is seen. For unions, maps, and nested
++     structure declarations, we need to indicate that it is okay that we
++     haven't seen any components yet. This will be updated after the structure
++     is fully parsed. */
++  sym->attr.zero_comp = 0;
++
++  /* Structures always act like derived-types with the SEQUENCE attribute */
++  gfc_add_sequence (&sym->attr, sym->name, NULL);
++
++  if (result) *result = sym;
++
++  return SUCCESS;
++}
++
++match
++gfc_match_map (void)
++{
++    /* Counter used to give unique internal names to map declarations. */
++    static unsigned int gfc_map_id = 0;
++    char name[GFC_MAX_SYMBOL_LEN + 1];
++    gfc_symbol *sym;
++    locus old_loc;
++
++    old_loc = gfc_current_locus;
++
++    if (gfc_current_state () != COMP_UNION)
++    {
++        gfc_current_locus = old_loc;
++        gfc_error ("MAP statement at %C illegal outside of union declaration");
++        return MATCH_ERROR;
++    }
++    if (gfc_match_eos () != MATCH_YES)
++    {
++        gfc_error ("Expected end of statement at %C after MAP statement");
++        gfc_current_locus = old_loc;
++        return MATCH_ERROR;
++    }
++
++    /* Make up a unique name for the map to store it in the symbol table. */
++    snprintf (name, GFC_MAX_SYMBOL_LEN + 1, "MM$%u", gfc_map_id++);
++
++    if (get_struct_decl (name, FL_STRUCT, &old_loc, &sym) == FAILURE)
++      return MATCH_ERROR;
++
++    gfc_new_block = sym;
++
++    return MATCH_YES;
++}
++
++match
++gfc_match_union (void)
++{
++    /* Counter used to give unique internal names to union declarations. */
++    static unsigned int gfc_union_id = 0;
++    char name[GFC_MAX_SYMBOL_LEN + 1];
++    gfc_symbol *sym;
++    locus old_loc;
++
++    old_loc = gfc_current_locus;
++
++    if (!gfc_comp_is_derived (gfc_current_state ()))
++    {
++        gfc_current_locus = old_loc;
++        gfc_error ("UNION statement at %C illegal outside of structure "
++                   "declaration");
++        return MATCH_ERROR;
++    }
++    if (gfc_match_eos () != MATCH_YES)
++    {
++        gfc_error ("Expected end of statement at %C after UNION statement");
++        gfc_current_locus = old_loc;
++        return MATCH_ERROR;
++    }
++
++    snprintf (name, GFC_MAX_SYMBOL_LEN + 1, "UU$%u", gfc_union_id++);
++    if (get_struct_decl (name, FL_UNION, &old_loc, &sym) == FAILURE)
++      return MATCH_ERROR;
++
++    gfc_new_block = sym;
++
++    return MATCH_YES;
++}
++
++/* Match the beginning of a structure declaration. This is similar to
++   matching the beginning of a derived type declaration, but the resulting
++   symbol has no access control or other interesting attributes. 
++   
++   If we are inside another structure declaration, we expect a field list
++   after the name of the structure. For example, in the following structure,
++   appointments have members START and END which are of ad-hoc structure type.
++   STRUCTURE /APPOINTMENT/ 
++     STRUCTURE /TIME/ START, END
++       INTEGER*1 HOUR, MINUTE, SECOND
++     END STRUCTURE
++     ...
++   END STRUCTURE
++   */
++
++match
++gfc_match_structure_decl (void)
++{
++    /* Counter used to give anonymous structures unique internal names. */
++    static unsigned int gfc_structure_id = 0;
++    char name[GFC_MAX_SYMBOL_LEN + 1];
++    gfc_symbol *sym;
++    match m;
++    locus where;
++
++    if(!gfc_option.flag_dec_structure)
++    {
++        gfc_error ("STRUCTURE at %C is a DEC extension, enable with "
++                   "-fdec-structure");
++        return MATCH_ERROR;
++    }
++
++    name[0] = '\0';
++
++    m = gfc_match (" /%n/", name);
++    if (m != MATCH_YES)
++    {
++        /* Non-nested structure declarations require a structure name. */
++        if (!gfc_comp_is_derived (gfc_current_state ()))
++        {
++            gfc_error ("Structure name expected in non-nested structure "
++                       "declaration at %C");
++            return MATCH_ERROR;
++        }
++        /* This is an anonymous structure; make up a unique name for it
++           (upper-case letters never make it to symbol names from the source).
++           The important thing is initializing the type declaration variable
++           and setting gfc_new_symbol, which is immediately used by
++           parse_structure () and variable_decl () to add fields of this type
++           and add components. */
++        snprintf (name, GFC_MAX_SYMBOL_LEN + 1, "SS$%u", gfc_structure_id++);
++    }
++    where = gfc_current_locus;
++    /* No field list allowed after non-nested structure declaration. */
++    if (!gfc_comp_is_derived (gfc_current_state ()) && gfc_match_eos () != MATCH_YES)
++    {
++        gfc_error ("Field list at %C illegal in non-nested structure "
++                   "declaration");
++        return MATCH_ERROR;
++    }
++
++    /* Make sure the name is not the name of an intrinsic type.  */
++    if (gfc_is_intrinsic_typename (name))
++    {
++      gfc_error ("Structure name '%s' at %C cannot be the same as an intrinsic "
++                 "type", name);
++      return MATCH_ERROR;
++    }
++
++    sprintf (name, gfc_dt_upper_string (name));
++    if (get_struct_decl (name, FL_STRUCT, &where, &sym) == FAILURE)
++      return MATCH_ERROR;
++
++    gfc_new_block = sym;
++    return MATCH_YES;
++}
++
++
+ 
+ /* Match the beginning of a derived type declaration.  If a type name
+    was the result of a function, then it is possible to have a symbol
+@@ -7652,9 +8138,10 @@ gfc_match_derived_decl (void)
+   match m;
+   match is_type_attr_spec = MATCH_NO;
+   bool seen_attr = false;
++  locus where;
+   gfc_interface *intr = NULL, *head;
+ 
+-  if (gfc_current_state () == COMP_DERIVED)
++  if (gfc_comp_is_derived (gfc_current_state ()))
+     return MATCH_NO;
+ 
+   name[0] = '\0';
+@@ -7686,7 +8173,11 @@ gfc_match_derived_decl (void)
+       return MATCH_ERROR;
+     }
+ 
+-  m = gfc_match (" %n%t", name);
++  m = gfc_match (" %n", name);
++  if (m != MATCH_YES)
++    return m;
++  where = gfc_current_locus;
++  m = gfc_match_eos ();
+   if (m != MATCH_YES)
+     return m;
+ 
+@@ -7740,6 +8231,7 @@ gfc_match_derived_decl (void)
+       intr->next = head;
+       gensym->generic = intr;
+       gensym->attr.if_source = IFSRC_DECL;
++      gensym->declared_at = where;
+     }
+ 
+   /* The symbol may already have the derived attribute without the
+@@ -7784,7 +8276,7 @@ gfc_match_derived_decl (void)
+ 
+       p->ts.type = BT_DERIVED;
+       p->ts.u.derived = extended;
+-      p->initializer = gfc_default_initializer (&p->ts);
++      p->initializer = gfc_default_initializer (&p->ts, false);
+ 
+       /* Set extension level.  */
+       if (extended->attr.extension == 255)
+@@ -7811,6 +8303,13 @@ gfc_match_derived_decl (void)
+   /* Take over the ABSTRACT attribute.  */
+   sym->attr.abstract = attr.abstract;
+ 
++  /* Normally the type is expected to have been completely parsed by the time
++     a field declaration with this type is seen. For unions, maps, and nested
++     structure declarations, we need to indicate that it is okay that we
++     haven't seen any components yet. This will be updated after the structure
++     is fully parsed. */
++  sym->attr.zero_comp = sym->components == NULL;
++
+   gfc_new_block = sym;
+ 
+   return MATCH_YES;
+diff --git a/gcc/fortran/dependency.c b/gcc/fortran/dependency.c
+index a40b891..2df1b76 100644
+--- a/gcc/fortran/dependency.c
++++ b/gcc/fortran/dependency.c
+@@ -1892,7 +1892,7 @@ gfc_dep_resolver (gfc_ref *lref, gfc_ref *rref, gfc_reverse *reverse)
+ 
+ 	      /* Now deal with the loop reversal logic:  This only works on
+ 		 ranges and is activated by setting
+-				reverse[n] == GFC_ENABLE_REVERSE
++				reverse[m] == GFC_ENABLE_REVERSE
+ 		 The ability to reverse or not is set by previous conditions
+ 		 in this dimension.  If reversal is not activated, the
+ 		 value GFC_DEP_BACKWARD is reset to GFC_DEP_OVERLAP.  */
+diff --git a/gcc/fortran/dump-parse-tree.c b/gcc/fortran/dump-parse-tree.c
+index 501a4eb..3491e2e 100644
+--- a/gcc/fortran/dump-parse-tree.c
++++ b/gcc/fortran/dump-parse-tree.c
+@@ -109,6 +109,10 @@ show_typespec (gfc_typespec *ts)
+       fprintf (dumpfile, "%s", ts->u.derived->name);
+       break;
+ 
++    case BT_UNION:
++      fprintf (dumpfile, "%s", ts->u.derived->name);
++      break;
++
+     case BT_CHARACTER:
+       if (ts->u.cl)
+ 	show_expr (ts->u.cl->length);
+diff --git a/gcc/fortran/expr.c b/gcc/fortran/expr.c
+index 6e17813..d0462d0 100644
+--- a/gcc/fortran/expr.c
++++ b/gcc/fortran/expr.c
+@@ -333,9 +333,9 @@ gfc_copy_expr (gfc_expr *p)
+ 
+ 	case BT_HOLLERITH:
+ 	case BT_LOGICAL:
+-	case BT_DERIVED:
+ 	case BT_CLASS:
+ 	case BT_ASSUMED:
++        case_struct_bt:
+ 	  break;		/* Already done.  */
+ 
+ 	case BT_PROCEDURE:
+@@ -1640,7 +1640,8 @@ simplify_const_ref (gfc_expr *p)
+ 
+ 	    case AR_FULL:
+ 	      if (p->ref->next != NULL
+-		  && (p->ts.type == BT_CHARACTER || p->ts.type == BT_DERIVED))
++		  && (p->ts.type == BT_CHARACTER 
++                      || gfc_bt_struct (p->ts.type)))
+ 		{
+ 		  for (c = gfc_constructor_first (p->value.constructor);
+ 		       c; c = gfc_constructor_next (c))
+@@ -1650,7 +1651,7 @@ simplify_const_ref (gfc_expr *p)
+ 			return FAILURE;
+ 		    }
+ 
+-		  if (p->ts.type == BT_DERIVED
++		  if (gfc_bt_struct (p->ts.type)
+ 			&& p->ref->next
+ 			&& (c = gfc_constructor_first (p->value.constructor)))
+ 		    {
+@@ -2674,6 +2675,58 @@ gfc_match_init_expr (gfc_expr **result)
+   return MATCH_YES;
+ }
+ 
++/* Apply an initialization expression to a typespec.
++   Can be used for both symbols and components.
++   Similar to add_init_expr_to_sym in decl.c; could probably be combined with
++   some effort. */
++void
++gfc_apply_init (gfc_typespec *ts, symbol_attribute *attr, gfc_expr *init)
++{
++  if (ts->type == BT_CHARACTER && !attr->pointer && init
++      && ts->u.cl
++      && ts->u.cl->length && ts->u.cl->length->expr_type == EXPR_CONSTANT)
++    {
++      int len;
++
++      gcc_assert (ts->u.cl && ts->u.cl->length);
++      gcc_assert (ts->u.cl->length->expr_type == EXPR_CONSTANT);
++      gcc_assert (ts->u.cl->length->ts.type == BT_INTEGER);
++
++      len = mpz_get_si (ts->u.cl->length->value.integer);
++
++      if (init->expr_type == EXPR_CONSTANT)
++	gfc_set_constant_character_len (len, init, -1);
++      else if (mpz_cmp (ts->u.cl->length->value.integer,
++			init->ts.u.cl->length->value.integer))
++	{
++	  gfc_constructor *ctor;
++	  ctor = gfc_constructor_first (init->value.constructor);
++
++	  if (ctor)
++	    {
++	      int first_len;
++	      bool has_ts = (init->ts.u.cl
++			     && init->ts.u.cl->length_from_typespec);
++
++	      /* Remember the length of the first element for checking
++		 that all elements *in the constructor* have the same
++		 length.  This need not be the length of the LHS!  */
++	      gcc_assert (ctor->expr->expr_type == EXPR_CONSTANT);
++	      gcc_assert (ctor->expr->ts.type == BT_CHARACTER);
++	      first_len = ctor->expr->value.character.length;
++
++	      for ( ; ctor; ctor = gfc_constructor_next (ctor))
++		if (ctor->expr->expr_type == EXPR_CONSTANT)
++		{
++		  gfc_set_constant_character_len (len, ctor->expr,
++						  has_ts ? -1 : first_len);
++		  ctor->expr->ts.u.cl->length = gfc_copy_expr (ts->u.cl->length);
++		}
++	    }
++	}
++    }
++}
++
+ 
+ /* Given an actual argument list, test to see that each argument is a
+    restricted expression and optionally if the expression type is
+@@ -3862,9 +3915,10 @@ gfc_has_default_initializer (gfc_symbol *der)
+ {
+   gfc_component *c;
+ 
+-  gcc_assert (der->attr.flavor == FL_DERIVED);
++  gcc_assert (gfc_fl_struct (der->attr.flavor));
+   for (c = der->components; c; c = c->next)
+-    if (c->ts.type == BT_DERIVED)
++  {
++    if (gfc_bt_struct (c->ts.type))
+       {
+         if (!c->attr.pointer
+ 	     && gfc_has_default_initializer (c->ts.u.derived))
+@@ -3877,26 +3931,124 @@ gfc_has_default_initializer (gfc_symbol *der)
+         if (c->initializer)
+ 	  return true;
+       }
++  }
+ 
+   return false;
+ }
+ 
+ 
+-/* Get an expression for a default initializer.  */
++/* Only the last initializer in a union matters. */
++static gfc_expr *
++get_last_init (gfc_symbol *uniont, gfc_component **mapp)
++{
++  gfc_component *map;
++  gfc_expr *init=NULL, *init2;
++  for (map = uniont->components; map; map = map->next)
++  {
++    if (!gfc_has_default_initializer (map->ts.u.derived))
++      continue;
++
++    init2 = gfc_default_initializer (&map->ts, false);
++    if (!init2)
++      continue;
++
++    if (init)
++    {
++      gfc_warning_now ("Initializer in map at %L overwritten by initializer in "
++                       "map at %L in union", &init->where, &init2->where);
++      gfc_free_expr (init);
++    }
++
++    init = init2;
++    if (mapp) *mapp = map;
++  }
++  if (!init) *mapp = NULL;
++  return init;
++}
++
++
++/* Fetch or generate an initializer for the given component.
++   Only generate an initializer if generate is true. */
++
++static gfc_expr *
++component_init (gfc_component *c, bool generate)
++{
++  gfc_component *map = NULL;
++  gfc_expr *init = NULL;
++
++  if (c->initializer) return c->initializer;
++
++  /* Recursively handle derived type components */
++  if (generate && (c->ts.type == BT_DERIVED || c->ts.type == BT_CLASS))
++    init = gfc_default_initializer (&c->ts, true);
++
++  else if (c->ts.type == BT_UNION && c->ts.u.derived->components)
++  {
++    /* TODO: keep _all_ map initializers here, and squash them together
++       during the translation phase (in trans-expr.c:gfc_conv_structure?)
++       to allow non-overlapping initializers across maps. */
++
++    /* Try to take an existing initializer from a map. */
++    gfc_constructor *ctor;
++    init = get_last_init (c->ts.u.derived, &map);
++
++    if (!map)
++    {
++      gcc_assert (init == NULL);
++      /* If no maps had an explicit initializer, and generate is not set, then
++         this union has no initializer. Otherwise generate an initializer from
++         the first map. */
++      /* TODO: Use the largest map / initialize the entire union.
++         This can only be determined in translation (?) */
++      if (!generate)
++        return NULL;
++      map = c->ts.u.derived->components;
++      init = gfc_default_initializer (&map->ts, true);
++    }
++
++    ctor = gfc_constructor_get ();
++    ctor->expr = init;
++    ctor->n.component = map;
++
++    init = gfc_get_structure_constructor_expr (c->ts.type, c->ts.kind, &c->loc);
++    init->ts = c->ts;
++    gfc_constructor_append (&init->value.constructor, ctor);
++  }
++
++  /* Simple components */
++  else if (generate)
++  {
++    init = gfc_build_default_init_expr (&c->ts, &c->loc);
++    gfc_apply_init (&c->ts, &c->attr, init);
++  }
++
++  return init;
++}
++
++
++/* Get an expression for a default initializer of a derived type. 
++   If -finit-derived is specified, generate default initialization expressions
++   for components that lack them as with gfc_build_default_init_expr. */
+ 
+ gfc_expr *
+-gfc_default_initializer (gfc_typespec *ts)
++gfc_default_initializer (gfc_typespec *ts, bool generate)
+ {
+-  gfc_expr *init;
++  gfc_expr *init, *tmp;
+   gfc_component *comp;
++  generate = gfc_option.flag_init_derived && generate;
+ 
+   /* See if we have a default initializer in this, but not in nested
+-     types (otherwise we could use gfc_has_default_initializer()).  */
+-  for (comp = ts->u.derived->components; comp; comp = comp->next)
+-    if (comp->initializer || comp->attr.allocatable
+-	|| (comp->ts.type == BT_CLASS && CLASS_DATA (comp)
+-	    && CLASS_DATA (comp)->attr.allocatable))
+-      break;
++     types (otherwise we could use gfc_has_default_initializer()).
++     We don't need to check if we are going to generate them. */
++  comp = ts->u.derived->components;
++  if (!generate)
++  {
++    for (; comp; comp = comp->next)
++      if (comp->initializer || comp->attr.allocatable
++          || (comp->ts.type == BT_CLASS && CLASS_DATA (comp)
++              && CLASS_DATA (comp)->attr.allocatable))
++        break;
++  }
+ 
+   if (!comp)
+     return NULL;
+diff --git a/gcc/fortran/gfortran.h b/gcc/fortran/gfortran.h
+index b6cc396..1073b2b 100644
+--- a/gcc/fortran/gfortran.h
++++ b/gcc/fortran/gfortran.h
+@@ -51,6 +51,16 @@ along with GCC; see the file COPYING3.  If not see
+ 
+ #define gfc_is_whitespace(c) ((c==' ') || (c=='\t'))
+ 
++/* Common macros to check structure-like types and flavors, since things like
++   STRUCTURES, MAPs and UNIONs are often treated similarly. */
++
++#define gfc_bt_struct(t) \
++  ((t) == BT_DERIVED || (t) == BT_UNION)
++#define gfc_fl_struct(f) \
++  ((f) == FL_DERIVED || (f) == FL_UNION || (f) == FL_STRUCT)
++#define case_struct_bt case BT_DERIVED: case BT_UNION
++#define case_struct_fl case FL_DERIVED: case FL_UNION: case FL_STRUCT
++
+ /* Stringization.  */
+ #define stringize(x) expand_macro(x)
+ #define expand_macro(x) # x
+@@ -202,6 +212,7 @@ typedef enum
+   ST_END_FILE, ST_FINAL, ST_FLUSH, ST_END_FORALL, ST_END_FUNCTION, ST_ENDIF,
+   ST_END_INTERFACE, ST_END_MODULE, ST_END_PROGRAM, ST_END_SELECT,
+   ST_END_SUBROUTINE, ST_END_WHERE, ST_END_TYPE, ST_ENTRY, ST_EQUIVALENCE,
++  ST_END_STRUCTURE,
+   ST_ERROR_STOP, ST_EXIT, ST_FORALL, ST_FORALL_BLOCK, ST_FORMAT, ST_FUNCTION,
+   ST_GOTO, ST_IF_BLOCK, ST_IMPLICIT, ST_IMPLICIT_NONE, ST_IMPORT,
+   ST_INQUIRE, ST_INTERFACE, ST_SYNC_ALL, ST_SYNC_MEMORY, ST_SYNC_IMAGES,
+@@ -210,6 +221,7 @@ typedef enum
+   ST_STOP, ST_SUBROUTINE, ST_TYPE, ST_USE, ST_WHERE_BLOCK, ST_WHERE, ST_WAIT,
+   ST_WRITE, ST_ASSIGNMENT, ST_POINTER_ASSIGNMENT, ST_SELECT_CASE, ST_SEQUENCE,
+   ST_SIMPLE_IF, ST_STATEMENT_FUNCTION, ST_DERIVED_DECL, ST_LABEL_ASSIGNMENT,
++  ST_STRUCTURE_DECL, ST_UNION, ST_END_UNION, ST_MAP, ST_END_MAP,
+   ST_ENUM, ST_ENUMERATOR, ST_END_ENUM, ST_SELECT_TYPE, ST_TYPE_IS, ST_CLASS_IS,
+   ST_OMP_ATOMIC, ST_OMP_BARRIER, ST_OMP_CRITICAL, ST_OMP_END_ATOMIC,
+   ST_OMP_END_CRITICAL, ST_OMP_END_DO, ST_OMP_END_MASTER, ST_OMP_END_ORDERED,
+@@ -234,12 +246,12 @@ typedef enum
+ interface_type;
+ 
+ /* Symbol flavors: these are all mutually exclusive.
+-   10 elements = 4 bits.  */
++   12 elements = 4 bits.  */
+ typedef enum sym_flavor
+ {
+   FL_UNKNOWN = 0, FL_PROGRAM, FL_BLOCK_DATA, FL_MODULE, FL_VARIABLE,
+   FL_PARAMETER, FL_LABEL, FL_PROCEDURE, FL_DERIVED, FL_NAMELIST,
+-  FL_VOID
++  FL_UNION, FL_STRUCT, FL_VOID
+ }
+ sym_flavor;
+ 
+@@ -924,7 +936,7 @@ typedef struct
+ 
+   union
+   {
+-    struct gfc_symbol *derived;	/* For derived types only.  */
++    struct gfc_symbol *derived;	/* For derived types or unions.  */
+     gfc_charlen *cl;		/* For character types only.  */
+     int pad;			/* For hollerith types only.  */
+   }
+@@ -978,6 +990,9 @@ typedef struct gfc_component
+ 
+   /* Needed for procedure pointer components.  */
+   struct gfc_typebound_proc *tb;
++
++  /* Pointer to MAP list for union types. */
++  struct gfc_symbol *maps;
+ }
+ gfc_component;
+ 
+@@ -2292,6 +2307,7 @@ typedef struct
+   int flag_module_private;
+   int flag_recursive;
+   int flag_init_local_zero;
++  int flag_init_derived;
+   int flag_init_integer;
+   int flag_init_integer_value;
+   int flag_init_real;
+@@ -2304,6 +2320,9 @@ typedef struct
+   int flag_realloc_lhs;
+   int flag_aggressive_function_elimination;
+   int flag_frontend_optimize;
++  int flag_dec_structure;
++  int flag_dec_member_dot;
++  int flag_loc_rval;
+ 
+   int fpe;
+   int rtcheck;
+@@ -2525,6 +2544,7 @@ gfc_try gfc_check_any_c_kind (gfc_typespec *);
+ int gfc_validate_kind (bt, int, bool);
+ int gfc_get_int_kind_from_width_isofortranenv (int size);
+ int gfc_get_real_kind_from_width_isofortranenv (int size);
++tree gfc_get_union_type (gfc_symbol *);
+ tree gfc_get_derived_type (gfc_symbol * derived);
+ extern int gfc_index_integer_kind;
+ extern int gfc_default_integer_kind;
+@@ -2615,7 +2635,8 @@ gfc_try gfc_copy_attr (symbol_attribute *, symbol_attribute *, locus *);
+ gfc_try gfc_add_component (gfc_symbol *, const char *, gfc_component **);
+ gfc_symbol *gfc_use_derived (gfc_symbol *);
+ gfc_symtree *gfc_use_derived_tree (gfc_symtree *);
+-gfc_component *gfc_find_component (gfc_symbol *, const char *, bool, bool);
++gfc_component *gfc_find_component (gfc_symbol *, const char *, bool, bool,
++                                   gfc_ref **);
+ 
+ gfc_st_label *gfc_get_st_label (int);
+ void gfc_free_st_label (gfc_st_label *);
+@@ -2791,7 +2812,9 @@ gfc_try gfc_check_pointer_assign (gfc_expr *, gfc_expr *);
+ gfc_try gfc_check_assign_symbol (gfc_symbol *, gfc_component *, gfc_expr *);
+ 
+ bool gfc_has_default_initializer (gfc_symbol *);
+-gfc_expr *gfc_default_initializer (gfc_typespec *);
++gfc_expr *gfc_default_initializer (gfc_typespec *, bool);
++gfc_expr *gfc_build_default_init_expr (gfc_typespec *, locus *);
++void gfc_apply_init (gfc_typespec *, symbol_attribute *, gfc_expr *);
+ gfc_expr *gfc_get_variable_expr (gfc_symtree *);
+ void gfc_add_full_array_ref (gfc_expr *, gfc_array_spec *);
+ gfc_expr * gfc_lval_expr_from_sym (gfc_symbol *);
+@@ -2885,6 +2908,7 @@ gfc_try gfc_ref_dimen_size (gfc_array_ref *, int dimen, mpz_t *, mpz_t *);
+ 
+ /* interface.c -- FIXME: some of these should be in symbol.c */
+ void gfc_free_interface (gfc_interface *);
++int gfc_compare_union_types (gfc_symbol *, gfc_symbol *);
+ int gfc_compare_derived_types (gfc_symbol *, gfc_symbol *);
+ int gfc_compare_types (gfc_typespec *, gfc_typespec *);
+ int gfc_compare_interfaces (gfc_symbol*, gfc_symbol*, const char *, int, int,
+@@ -2930,6 +2954,8 @@ void gfc_module_done_2 (void);
+ void gfc_dump_module (const char *, int);
+ bool gfc_check_symbol_access (gfc_symbol *);
+ void gfc_free_use_stmts (gfc_use_list *);
++const char *gfc_dt_lower_string (const char *);
++const char *gfc_dt_upper_string (const char *);
+ 
+ /* primary.c */
+ symbol_attribute gfc_variable_attr (gfc_expr *, gfc_typespec *);
+diff --git a/gcc/fortran/gfortran.texi b/gcc/fortran/gfortran.texi
+index a27903f..451eb59 100644
+--- a/gcc/fortran/gfortran.texi
++++ b/gcc/fortran/gfortran.texi
+@@ -1960,6 +1960,9 @@ C
+       end
+ @end smallexample
+ 
++Use of @code{%LOC()} as an rvalue is supported with the flag
++@option{-floc-rval} (its behavior is identical to the @code{LOC()} intrinsic).
++
+ For details refer to the g77 manual
+ @uref{http://gcc.gnu.org/@/onlinedocs/@/gcc-3.4.6/@/g77/@/index.html#Top}.
+ 
+@@ -1976,48 +1979,38 @@ AUTOMATIC forces all variable declared with it to be on the stack.
+ 
+ AUTOMATIC overrides -fno-automatic.
+ 
+-@node Extensions not implemented in GNU Fortran
+-@section Extensions not implemented in GNU Fortran
+-@cindex extensions, not implemented
++@node Optional DEC extension support
++@subsection Optional DEC extension support
++@cindex extensions, dec
+ 
+-The long history of the Fortran language, its wide use and broad
+-userbase, the large number of different compiler vendors and the lack of
+-some features crucial to users in the first standards have lead to the
+-existence of a number of important extensions to the language.  While
+-some of the most useful or popular extensions are supported by the GNU
+-Fortran compiler, not all existing extensions are supported.  This section
+-aims at listing these extensions and offering advice on how best make
+-code that uses them running with the GNU Fortran compiler.
++Long long ago in a land far far away, in the time before Fortran standards
++existed, compiler writers loved to add extensions to Fortran for anyone who
++asked them nicely. The most popular of these extensions were implemented by
++Digital Equipment Corporation (DEC). Since they were so popular they were
++maintained in the Digital (and since Intel) compiler long after standards were
++introduced. Unfortunately these extensions remain in use by a number of users.
+ 
+-@c More can be found here:
+-@c   -- http://gcc.gnu.org/onlinedocs/gcc-3.4.6/g77/Missing-Features.html
+-@c   -- the list of Fortran and libgfortran bugs closed as WONTFIX:
+-@c      http://tinyurl.com/2u4h5y
++GNU Fortran provides selective automatic support for some of these
++extensions, described in the previous section @ref{Extensions implemented in
++GNU Fortran}. Other DEC extensions are so heinous that GNU Fortran requires the
++user to explicitly enable them; these are the "optional" DEC extensions,
++described here.
+ 
+ @menu
+ * STRUCTURE and RECORD::
+-@c * UNION and MAP::
+-* ENCODE and DECODE statements::
+-* Variable FORMAT expressions::
+-@c * Q edit descriptor::
+-@c * AUTOMATIC statement::
+-@c * TYPE and ACCEPT I/O Statements::
+-@c * .XOR. operator::
+-@c * CARRIAGECONTROL, DEFAULTFILE, DISPOSE and RECORDTYPE I/O specifiers::
+-@c * Omitted arguments in procedure call::
+-* Alternate complex function syntax::
++* UNION and MAP::
+ @end menu
+ 
+-
+ @node STRUCTURE and RECORD
+-@subsection @code{STRUCTURE} and @code{RECORD}
++@subsubsection @code{STRUCTURE} and @code{RECORD}
+ @cindex @code{STRUCTURE}
+ @cindex @code{RECORD}
+ 
+-Record structures are a pre-Fortran-90 vendor extension to create
+-user-defined aggregate data types.  GNU Fortran does not support
+-record structures, only Fortran 90's ``derived types'', which have
+-a different syntax.
++Record structures are a pre-Fortran-90 DEC extension to create
++user-defined aggregate data types. Support for record structures in GNU
++Fortran can be enabled with the @option{-fdec-structure} compile option.
++If you have a choice, you should instead use Fortran 90's ``derived types'',
++which have a different syntax. 
+ 
+ In many cases, record structures can easily be converted to derived types.
+ To convert, replace @code{STRUCTURE /}@var{structure-name}@code{/}
+@@ -2026,6 +2019,10 @@ by @code{TYPE} @var{type-name}.  Additionally, replace
+ @code{TYPE(}@var{type-name}@code{)}. Finally, in the component access,
+ replace the period (@code{.}) by the percent sign (@code{%}).
+ 
++Note that component access by period can be enabled for derived types
++separately from structure/record support with @option{-fdec-member-dot};
++however, it is enabled automatically with @option{-fdec-structure}.
++
+ Here is an example of code using the non portable record structure syntax:
+ 
+ @example
+@@ -2083,16 +2080,172 @@ store_catalog(12) = pear
+ print *, store_catalog(12)
+ @end example
+ 
++@noindent
++Structures and derived types differ in a few ways:
+ 
+-@c @node UNION and MAP
+-@c @subsection @code{UNION} and @code{MAP}
+-@c @cindex @code{UNION}
+-@c @cindex @code{MAP}
+-@c
+-@c For help writing this one, see
+-@c http://www.eng.umd.edu/~nsw/ench250/fortran1.htm#UNION and
+-@c http://www.tacc.utexas.edu/services/userguides/pgi/pgiws_ug/pgi32u06.htm
++@itemize @bullet
++@item Structures act like derived types with the @code{SEQUENCE} attribute.
++Otherwise they may contain no specifiers.
++
++@item Structures may contain a variable with the name @code{%FILL}; this will
++create an anonymous component which cannot be referenced but fills space just
++like a component for alignment purposes. For example, the following structure
++will take up sixteen bytes:
++
++@smallexample 
++structure /useless/
++  integer(4) i
++  integer(8) %FILL
++end structure
++@end smallexample
++
++@item Structures may share names with other symbols. For example, the following
++is invalid for derived types, but valid for structures:
+ 
++@smallexample
++structure /Header/
++  ! ...
++end structure
++record /Header/ header
++@end smallexample
++
++@item Structures may be defined 'ad-hoc' within another parent structure. The
++type names for these structures may be ommitted, in which case the structure
++type itself is anonymous, and other structures of the same type cannot be
++instantiated. The following shows some examples:
++
++@example
++type appointment
++  ! 'ad-hoc' structure definition; app_time is an array of two 'time'
++  structure /time/ app_time (2) 
++    integer(1) hour, minute
++  end structure
++  character(10) memo
++end type appointment
++
++! The 'time' structure is still usable
++record /time/ now
++now = time(5, 30)
++
++...
++
++type appointment
++  ! anonymous ad-hoc structure definition
++  structure start, end
++    integer(1) hour, minute
++  end structure
++  character(10) memo
++end type appointment
++@end example
++
++@item Structures may contain @code{UNION} declarations. For more detail see the
++section on @ref{UNION and MAP}.
++
++@item Structures support old-style initialization of components, identical to
++those described in @ref{Old-style variable initialization}.
++@end itemize
++
++@node UNION and MAP
++@subsubsection @code{UNION} and @code{MAP}
++@cindex @code{UNION}
++@cindex @code{MAP}
++
++Unions are a DEC extension which were commonly used with the non-standard
++@ref{STRUCTURE and RECORD} extensions. Use of @code{UNION} and @code{MAP} is
++automatically enabled with @option{-fdec-structure}.
++
++A @code{UNION} declaration occurs within a structure; within the definition of
++each union is a number of @code{MAP} definitions. Each @code{MAP} shares
++storage with its sibling maps (in the same union), and the size of the union
++is the size of the largest map within it, just as with unions in C. The major
++difference is that component references do not indicate which union or map the
++component is in (the compiler gets to figure that out).
++
++Here is a small example:
++@smallexample
++structure /words_long/
++union
++  map
++    integer(2) w0, w1, w2
++  end map
++  map
++    integer(4) long
++  end map
++end union
++end structure
++@end smallexample
++
++The two maps share memory, and the size of the union is ultimately six bytes:
++
++@example
++0    1    2    3    4   5   6     Byte offset
++-------------------------------
++|    |    |    |    |    |    |
++-------------------------------
++
++^    W0   ^    W1   ^    W2   ^
++ \-------/ \-------/ \-------/
++
++^       LONG        ^  unused ^
++ \-----------------/ \-------/
++@end example
++
++Following is an example mirroring the layout of an Intel x86_64 register:
++
++@example
++structure /reg/
++  union    ! rax
++    map
++      integer*8 rx         ! rax
++    end map
++    map
++      integer*4 rh         ! rah
++      union   ! eax
++        map
++          integer*4 rl     ! ral
++        end map
++        map
++          integer*4 ex     ! eax
++        end map
++        map
++          integer*2 eh     ! eah
++          union     ! ax
++            map
++              integer*2 el ! eal
++            end map
++            map
++              integer*2 x  ! ax
++            end map
++            map
++              integer*1 h  ! ah
++              integer*1 l  ! al
++            end map
++          end union ! ax
++        end map
++      end union ! eax
++    end map
++  end union ! rax
++end structure
++
++record /reg/ a
++
++! After this assignment...
++a.rx = z'AABBCCCCFFFFFFFF'
++
++! The following is true:
++!
++! a.rx == z'AABBCCCCFFFFFFFF'
++! a.rh ==         z'FFFFFFFF'
++! a.rl == z'AABBCCCC'
++!
++! a.ex == z'AABBCCCC'
++! a.eh ==     z'CCCC'
++! a.el == z'AABB'
++!
++!  a.x == z'AABB'
++!  a.h ==   z'BB'
++!  a.l == z'AA'
++@end example
+ 
+ @node ENCODE and DECODE statements
+ @subsection @code{ENCODE} and @code{DECODE} statements
+diff --git a/gcc/fortran/interface.c b/gcc/fortran/interface.c
+index 037b041..5f2446f 100644
+--- a/gcc/fortran/interface.c
++++ b/gcc/fortran/interface.c
+@@ -383,19 +383,142 @@ gfc_match_end_interface (void)
+ }
+ 
+ 
++static int
++compare_components (gfc_component *cmp1, gfc_component *cmp2,
++    gfc_symbol *derived1, gfc_symbol *derived2)
++{
++  gfc_symbol *d1, *d2;
++  bool anonymous = false;
++
++  d1 = cmp1->ts.u.derived;
++  d2 = cmp2->ts.u.derived;
++  if (   (d1 && (d1->attr.flavor == FL_STRUCT || d1->attr.flavor == FL_UNION)
++          && ISUPPER (cmp1->name[1]))
++      || (d2 && (d2->attr.flavor == FL_STRUCT || d2->attr.flavor == FL_UNION)
++          && ISUPPER (cmp1->name[1])))
++    anonymous = true;
++
++  if (!anonymous && strcmp (cmp1->name, cmp2->name) != 0)
++    return 0;
++
++  if (cmp1->attr.access != cmp2->attr.access)
++    return 0;
++
++  if (cmp1->attr.pointer != cmp2->attr.pointer)
++    return 0;
++
++  if (cmp1->attr.dimension != cmp2->attr.dimension)
++    return 0;
++
++ if (cmp1->attr.allocatable != cmp2->attr.allocatable)
++    return 0;
++
++  if (cmp1->attr.dimension && gfc_compare_array_spec (cmp1->as, cmp2->as) == 0)
++    return 0;
++
++  /* Make sure that link lists do not put this function into an
++     endless recursive loop!  */
++  if (!(cmp1->ts.type == BT_DERIVED && derived1 == cmp1->ts.u.derived)
++        && !(cmp2->ts.type == BT_DERIVED && derived2 == cmp2->ts.u.derived)
++        && gfc_compare_types (&cmp1->ts, &cmp2->ts) == 0)
++    return 0;
++
++  else if ((cmp1->ts.type == BT_DERIVED && derived1 == cmp1->ts.u.derived)
++            && !(cmp1->ts.type == BT_DERIVED && derived1 == cmp1->ts.u.derived))
++    return 0;
++
++  else if (!(cmp1->ts.type == BT_DERIVED && derived1 == cmp1->ts.u.derived)
++            && (cmp1->ts.type == BT_DERIVED && derived1 == cmp1->ts.u.derived))
++    return 0;
++
++  return 1;
++}
++
++
++/* Compare two union types by comparing the components of their maps.
++   Because unions and maps are anonymous their types get special internal
++   names; therefore the usual derived type comparison will fail on them.
++
++   Returns nonzero if equal, as with gfc_compare_derived_types. Also as with
++   gfc_compare_derived_types, 'equal' is closer to meaning 'duplicate
++   definitions' than 'equivalent structure'. */
++
++int
++gfc_compare_union_types (gfc_symbol *un1, gfc_symbol *un2)
++{
++  gfc_component *map1, *map2, *cmp1, *cmp2;
++
++  if (un1->attr.flavor != FL_UNION || un2->attr.flavor != FL_UNION)
++    return 0;
++
++  map1 = un1->components;
++  map2 = un2->components;
++
++  /* In terms of 'equality' here we are worried about types which are
++     declared the same in two places, not types that represent equivalent
++     structures. (This is common because of FORTRAN's weird scoping rules.)
++     Though two unions with their maps in different orders could be equivalent,
++     we will say they are not equal for the purposes of this test; therefore
++     we compare the maps sequentially. */
++  for (;;)
++  {
++    cmp1 = map1->ts.u.derived->components;
++    cmp2 = map2->ts.u.derived->components;
++    for (;;)
++    {
++      /* No two fields will ever point to the same map type unless they are
++         the same component, because one map field is created with its type
++         declaration. Therefore don't worry about recursion here. */
++      /* TODO: worry about recursion into parent types of the unions? */
++      if (compare_components (cmp1, cmp2,
++            map1->ts.u.derived, map2->ts.u.derived) == 0)
++        return 0;
++
++      cmp1 = cmp1->next;
++      cmp2 = cmp2->next;
++
++      if (cmp1 == NULL && cmp2 == NULL)
++        break;
++      if (cmp1 == NULL || cmp2 == NULL)
++        return 0;
++    }
++
++    map1 = map1->next;
++    map2 = map2->next;
++
++    if (map1 == NULL && map2 == NULL)
++      break;
++    if (map1 == NULL || map2 == NULL)
++      return 0;
++  }
++
++  return 1;
++}
++
++
+ /* Compare two derived types using the criteria in 4.4.2 of the standard,
+    recursing through gfc_compare_types for the components.  */
+ 
+ int
+ gfc_compare_derived_types (gfc_symbol *derived1, gfc_symbol *derived2)
+ {
+-  gfc_component *dt1, *dt2;
++  gfc_component *cmp1, *cmp2;
++  bool anonymous = false;
+ 
+   if (derived1 == derived2)
+     return 1;
+ 
+   gcc_assert (derived1 && derived2);
+ 
++  /* MAP and anonymous STRUCTURE types have internal names of the form
++     mM* and sS* (we can get away with this because source names are converted
++     to lowercase). Compare anonymous type names specially because each
++     gets a unique name when it is declared. */
++  anonymous = (derived1->name[0] == derived2->name[0]
++      && derived1->name[1] && derived2->name[1] && derived2->name[2]
++      && derived1->name[1] == (char) TOUPPER (derived1->name[0])
++      && derived2->name[1] == (char) TOUPPER (derived2->name[0]));
++
+   /* Special case for comparing derived types across namespaces.  If the
+      true names and module names are the same and the module name is
+      nonnull, then they are equal.  */
+@@ -404,12 +527,14 @@ gfc_compare_derived_types (gfc_symbol *derived1, gfc_symbol *derived2)
+       && strcmp (derived1->module, derived2->module) == 0)
+     return 1;
+ 
+-  /* Compare type via the rules of the standard.  Both types must have
+-     the SEQUENCE or BIND(C) attribute to be equal.  */
+-
+-  if (strcmp (derived1->name, derived2->name))
++  if (strcmp (derived1->name, derived2->name) != 0 && !anonymous)
+     return 0;
+ 
++  /* Compare type via the rules of the standard.  Both types must have
++     the SEQUENCE or BIND(C) attribute to be equal. STRUCTUREs are special
++     because they can be anonymous; therefore two structures with different
++     names may be equal.  */
++
+   if (derived1->component_access == ACCESS_PRIVATE
+       || derived2->component_access == ACCESS_PRIVATE)
+     return 0;
+@@ -418,53 +543,30 @@ gfc_compare_derived_types (gfc_symbol *derived1, gfc_symbol *derived2)
+       && !(derived1->attr.is_bind_c && derived2->attr.is_bind_c))
+     return 0;
+ 
+-  dt1 = derived1->components;
+-  dt2 = derived2->components;
++  if ((derived1->attr.zero_comp && !derived2->attr.zero_comp)
++      || (!derived1->attr.zero_comp && derived2->attr.zero_comp))
++    return 0;
++
++  if (derived1->attr.zero_comp || derived2->attr.zero_comp)
++    return 1;
++
++  cmp1 = derived1->components;
++  cmp2 = derived2->components;
+ 
+   /* Since subtypes of SEQUENCE types must be SEQUENCE types as well, a
+      simple test can speed things up.  Otherwise, lots of things have to
+      match.  */
+   for (;;)
+     {
+-      if (strcmp (dt1->name, dt2->name) != 0)
+-	return 0;
+-
+-      if (dt1->attr.access != dt2->attr.access)
+-	return 0;
++      if (!compare_components (cmp1, cmp2, derived1, derived2))
++        return 0;
+ 
+-      if (dt1->attr.pointer != dt2->attr.pointer)
+-	return 0;
+-
+-      if (dt1->attr.dimension != dt2->attr.dimension)
+-	return 0;
+-
+-     if (dt1->attr.allocatable != dt2->attr.allocatable)
+-	return 0;
+-
+-      if (dt1->attr.dimension && gfc_compare_array_spec (dt1->as, dt2->as) == 0)
+-	return 0;
+-
+-      /* Make sure that link lists do not put this function into an
+-	 endless recursive loop!  */
+-      if (!(dt1->ts.type == BT_DERIVED && derived1 == dt1->ts.u.derived)
+-	    && !(dt2->ts.type == BT_DERIVED && derived2 == dt2->ts.u.derived)
+-	    && gfc_compare_types (&dt1->ts, &dt2->ts) == 0)
+-	return 0;
+-
+-      else if ((dt1->ts.type == BT_DERIVED && derived1 == dt1->ts.u.derived)
+-		&& !(dt1->ts.type == BT_DERIVED && derived1 == dt1->ts.u.derived))
+-	return 0;
+-
+-      else if (!(dt1->ts.type == BT_DERIVED && derived1 == dt1->ts.u.derived)
+-		&& (dt1->ts.type == BT_DERIVED && derived1 == dt1->ts.u.derived))
+-	return 0;
++      cmp1 = cmp1->next;
++      cmp2 = cmp2->next;
+ 
+-      dt1 = dt1->next;
+-      dt2 = dt2->next;
+-
+-      if (dt1 == NULL && dt2 == NULL)
++      if (cmp1 == NULL && cmp2 == NULL)
+ 	break;
+-      if (dt1 == NULL || dt2 == NULL)
++      if (cmp1 == NULL || cmp2 == NULL)
+ 	return 0;
+     }
+ 
+@@ -494,10 +596,14 @@ gfc_compare_types_generic (gfc_typespec *ts1, gfc_typespec *ts2, enum match_type
+       && (ts1->u.derived->attr.sequence || ts1->u.derived->attr.is_bind_c))
+     return 1;
+ 
++  if (ts1->type == BT_UNION && ts2->type == BT_UNION)
++    return gfc_compare_union_types (ts1->u.derived, ts2->u.derived);
++
+   if (ts1->type != ts2->type
+-      && ((ts1->type != BT_DERIVED && ts1->type != BT_CLASS)
+-	  || (ts2->type != BT_DERIVED && ts2->type != BT_CLASS)))
++      && (   (ts1->type != BT_DERIVED && ts1->type != BT_CLASS)
++          || (ts2->type != BT_DERIVED && ts2->type != BT_CLASS)))
+     return 0;
++
+   if (ts1->type != BT_DERIVED && ts1->type != BT_CLASS)
+     {
+     if (mtype == MATCH_PROMOTABLE)
+@@ -511,7 +617,7 @@ gfc_compare_types_generic (gfc_typespec *ts1, gfc_typespec *ts2, enum match_type
+   if (gfc_type_compatible (ts1, ts2))
+     return 1;
+ 
+-  return gfc_compare_derived_types (ts1->u.derived ,ts2->u.derived);
++  return 0;
+ }
+ 
+ int
+@@ -1478,7 +1584,7 @@ check_interface0 (gfc_interface *p, const char *interface_name)
+ 	 functions or subroutines.  */
+       if (((!p->sym->attr.function && !p->sym->attr.subroutine)
+ 	   || !p->sym->attr.if_source)
+-	  && p->sym->attr.flavor != FL_DERIVED)
++	  && !gfc_fl_struct (p->sym->attr.flavor))
+ 	{
+ 	  if (p->sym->attr.external)
+ 	    gfc_error ("Procedure '%s' in %s at %L has no explicit interface",
+@@ -1492,17 +1598,21 @@ check_interface0 (gfc_interface *p, const char *interface_name)
+ 
+       /* Verify that procedures are either all SUBROUTINEs or all FUNCTIONs.  */
+       if ((psave->sym->attr.function && !p->sym->attr.function
+-	   && p->sym->attr.flavor != FL_DERIVED)
++	   && !gfc_fl_struct (p->sym->attr.flavor))
+ 	  || (psave->sym->attr.subroutine && !p->sym->attr.subroutine))
+ 	{
+-	  if (p->sym->attr.flavor != FL_DERIVED)
++	  if (!gfc_fl_struct (p->sym->attr.flavor))
+ 	    gfc_error ("In %s at %L procedures must be either all SUBROUTINEs"
+ 		       " or all FUNCTIONs", interface_name,
+ 		       &p->sym->declared_at);
+-	  else
++	  else if (p->sym->attr.flavor == FL_DERIVED)
+ 	    gfc_error ("In %s at %L procedures must be all FUNCTIONs as the "
+ 		       "generic name is also the name of a derived type",
+ 		       interface_name, &p->sym->declared_at);
++          else
++            gfc_error ("In %s at %L procedures must be all FUNCTIONs as the "
++                       "generic name is also the name of a structure type",
++                       interface_name, &p->sym->declared_at);
+ 	  return 1;
+ 	}
+ 
+@@ -1559,8 +1669,8 @@ check_interface1 (gfc_interface *p, gfc_interface *q0,
+ 	if (p->sym->name == q->sym->name && p->sym->module == q->sym->module)
+ 	  continue;
+ 
+-	if (p->sym->attr.flavor != FL_DERIVED
+-	    && q->sym->attr.flavor != FL_DERIVED
++	if (!gfc_fl_struct (p->sym->attr.flavor)
++	    && !gfc_fl_struct (q->sym->attr.flavor)
+ 	    && gfc_compare_interfaces (p->sym, q->sym, q->sym->name,
+ 				       generic_flag, 0, NULL, 0, NULL, NULL))
+ 	  {
+@@ -3343,12 +3453,12 @@ gfc_search_interface (gfc_interface *intr, int sub_flag,
+     {
+       for (; intr; intr = intr->next)
+ 	{
+-	  if (intr->sym->attr.flavor == FL_DERIVED)
++	  if (gfc_fl_struct (intr->sym->attr.flavor))
+ 	    continue;
+ 	  if (sub_flag && intr->sym->attr.function)
+ 	    continue;
+ 	  if (!sub_flag && intr->sym->attr.subroutine)
+-	continue;
++	    continue;
+ 
+ 	  if (gfc_arglist_matches_symbol (ap, intr->sym, mtypes[i]))
+ 	    {
+diff --git a/gcc/fortran/invoke.texi b/gcc/fortran/invoke.texi
+index b0b43d8..2d91b35 100644
+--- a/gcc/fortran/invoke.texi
++++ b/gcc/fortran/invoke.texi
+@@ -227,6 +227,17 @@ given they are treated as if the first column contained a blank.  If the
+ @option{-fd-lines-as-comments} option is given, they are treated as
+ comment lines.
+ 
++@item -fdec-member-dot
++@opindex @code{fdec-member-dot}
++Enable dot (@code{.}) as a member separator (in addition to the usual @code{%}).
++This is enabled automatically with @option{-fdec-structure}.
++
++@item -fdec-structure
++@opindex @code{fdec-structure}
++Enable DEC old-style @code{STRUCTURE} and @code{RECORD}. This is provided for
++compatibility; Fortran 90 derived types should be used instead where
++possible. This implies @option{-fdec-member-dot}.
++
+ @item -fdefault-double-8
+ @opindex @code{fdefault-double-8}
+ Set the @code{DOUBLE PRECISION} type to an 8 byte wide type.  If
+diff --git a/gcc/fortran/lang.opt b/gcc/fortran/lang.opt
+index 6231f35..83ef02f 100644
+--- a/gcc/fortran/lang.opt
++++ b/gcc/fortran/lang.opt
+@@ -373,6 +373,18 @@ fd-lines-as-comments
+ Fortran RejectNegative
+ Treat lines with 'D' in column one as comments
+ 
++fdec-member-dot
++Fortran
++Enable dot (`.`) as a member separator (in addition to the usual `%`).
++
++fdec-static
++Fortran
++Enable STATIC and AUTOMATIC attributes.
++
++fdec-structure
++Fortran
++Enable DEC STRUCTURE extension.
++
+ fdefault-double-8
+ Fortran
+ Set the default double precision kind to an 8 byte wide type
+@@ -481,6 +493,14 @@ finit-real=
+ Fortran RejectNegative Joined
+ -finit-real=<zero|nan|inf|-inf>	Initialize local real variables
+ 
++finit-derived
++Fortran
++Automatically initialize local derived type variables
++
++floc-rval
++Fortran
++Enable the use of %LOC as an rvalue, like the built-in LOC().
++
+ fmax-array-constructor=
+ Fortran RejectNegative Joined UInteger
+ -fmax-array-constructor=<n>	Maximum number of objects in an array constructor
+diff --git a/gcc/fortran/libgfortran.h b/gcc/fortran/libgfortran.h
+index 8bd88b2..a695934 100644
+--- a/gcc/fortran/libgfortran.h
++++ b/gcc/fortran/libgfortran.h
+@@ -129,7 +129,7 @@ libgfortran_stat_codes;
+    used in the run-time library for IO.  */
+ typedef enum
+ { BT_UNKNOWN = 0, BT_INTEGER, BT_LOGICAL, BT_REAL, BT_COMPLEX,
+-  BT_DERIVED, BT_CHARACTER, BT_CLASS, BT_PROCEDURE, BT_HOLLERITH, BT_VOID,
+-  BT_ASSUMED
++  BT_DERIVED, BT_CHARACTER, BT_CLASS, BT_PROCEDURE, BT_HOLLERITH, BT_UNION,
++  BT_VOID, BT_ASSUMED
+ }
+ bt;
+diff --git a/gcc/fortran/match.c b/gcc/fortran/match.c
+index 9b70574..e9015a6 100644
+--- a/gcc/fortran/match.c
++++ b/gcc/fortran/match.c
+@@ -112,6 +112,126 @@ gfc_op2string (gfc_intrinsic_op op)
+ 
+ /******************** Generic matching subroutines ************************/
+ 
++/* Matches a member separator. With F90+ this is '%', but with
++   -fdec-member-dot we must carefully match dot ('.').
++   Because operators are spelled ".op.", "x.y.z" can be either a component
++   access (x->y)->z or a binary operation y(x,z). Here we choose to deal with
++   the "x.y.z" ambiguity in a manner consistent with Intel:
++     (1) If any user defined operator ".y." exists, this is always y(x,z)
++         (even if ".y." is the wrong type and/or x has a member y).
++     (2) Otherwise if x has a member y, and y is itself a derived type,
++         this is (x->y)->z, even if an intrinsic operator exists which 
++         can handle (x,z). 
++     (3) If x has no member y or (x->y) is not a derived type but ".y." 
++         is an intrinsic operator (such as ".eq."), this is y(x,z).
++     (4) Lastly if there is no operator ".y." and x has no member "y", it is an
++         error.  
++   It is worth noting that [fortunately] Intel does not support mixed use of
++   member accessors within a single string, nor does it support parenthesised
++   member accesses (therefore neither do we).
++   That is, even if x has component y and y has component z, the following
++   are all syntax errors:  "x%y.z"  "x.y%z"  "(x.y).z"  "(x%y)%z"
++ */
++
++match
++gfc_match_member_sep(gfc_symbol *sym)
++{
++    char name[GFC_MAX_SYMBOL_LEN + 1];
++    locus dot_loc, start_loc;
++    gfc_intrinsic_op iop;
++    match m;
++    gfc_symbol *tsym;
++    gfc_component *c;
++
++    /* Thank god; '%' is an unambiguous member separator. */
++    if (gfc_match_char ('%') == MATCH_YES)
++        return MATCH_YES;
++
++    /* Only continue if dot member separators are enabled. */
++    if (!gfc_option.flag_dec_member_dot || !sym)
++        return MATCH_NO;
++
++    tsym = NULL;
++
++    /* We may be given either a derived type variable or the derived type
++       declaration itself (which actually contains the components); 
++       if this is a member access we need the latter to check components. */
++    if (gfc_fl_struct (sym->attr.flavor))
++        tsym = sym;
++    else if (gfc_bt_struct (sym->ts.type))
++        tsym = sym->ts.u.derived;
++    else
++        return MATCH_NO;
++
++    iop = INTRINSIC_NONE;
++    name[0] = '\0';
++    m = MATCH_NO;
++
++    /* If we have to reject, come back here later. */
++    start_loc = gfc_current_locus;
++
++    /* Look for a component access next. */
++    if (gfc_match_char ('.') != MATCH_YES)
++        return MATCH_NO;
++
++    /* If we accept, come back here. */
++    dot_loc = gfc_current_locus;
++
++    /* Try to match a symbol name following '.' */
++    if (gfc_match_name (name) != MATCH_YES)
++    {
++        gfc_error ("Expected structure component or operator name "
++                   "after '.' at %C");
++        goto error;
++    }
++
++    /* If no dot follows we have "x.y" which must be a component access.
++       Ensure the leading symbol is a derived type variable. */
++    if (gfc_match_char ('.') != MATCH_YES)
++        goto yes;
++
++    /* Now we have a string "x.y.z" which could be a nested member access
++       (x->y)->z or a binary operation y on x and z. */
++
++    /* First use any user-defined operators ".y." */
++    if (gfc_find_uop (name, sym->ns) != NULL)
++        goto no;
++
++    /* Match accesses to existing derived-type components for 
++       derived-type vars: "x.y.z" = (x->y)->z */
++    c = gfc_find_component(tsym, name, false, true, NULL);
++    if (c && (c->ts.type == BT_DERIVED || c->ts.type == BT_CLASS))
++        goto yes;
++
++    /* If y is not a component or has no members, try intrinsic operators. */
++    gfc_current_locus = start_loc;
++    if (gfc_match_intrinsic_op (&iop) != MATCH_YES)
++    {
++        /* If ".y." is not an intrinsic operator but y was a valid non-
++           structure component, match and leave the trailing dot to be 
++           dealt with later. */
++        if (c)
++            goto yes;
++
++        gfc_error ("'%s' is neither a defined operator nor a "
++                   "structure component in dotted string at %C", name);
++        goto error;
++    }
++
++    /* .y. is an intrinsic operator, overriding any possible member access. */
++    goto no;
++
++    /* Return keeping the current locus consistent with the match result. */
++error:
++    m = MATCH_ERROR;
++no:
++    gfc_current_locus = start_loc;
++    return m;
++yes:
++    gfc_current_locus = dot_loc;
++    return MATCH_YES;
++}
++
+ /* This function scans the current statement counting the opened and closed
+    parenthesis to make sure they are balanced.  */
+ 
+@@ -1941,7 +2061,7 @@ match_derived_type_spec (gfc_typespec *ts)
+   if (derived && derived->attr.flavor == FL_PROCEDURE && derived->attr.generic)
+     derived = gfc_find_dt_in_generic (derived);
+ 
+-  if (derived && derived->attr.flavor == FL_DERIVED)
++  if (derived && gfc_fl_struct (derived->attr.flavor))
+     {
+       ts->type = BT_DERIVED;
+       ts->u.derived = derived;
+@@ -5243,7 +5363,7 @@ select_intrinsic_set_tmp (gfc_typespec *ts)
+   gfc_symtree *tmp;
+   int charlen = 0;
+ 
+-  if (ts->type == BT_CLASS || ts->type == BT_DERIVED)
++  if (ts->type == BT_CLASS || gfc_bt_struct (ts->type))
+     return NULL;
+ 
+   if (select_type_stack->selector->ts.type == BT_CLASS
+diff --git a/gcc/fortran/match.h b/gcc/fortran/match.h
+index 16b1cc9..935d7b6 100644
+--- a/gcc/fortran/match.h
++++ b/gcc/fortran/match.h
+@@ -59,6 +59,7 @@ match gfc_match_char (char);
+ match gfc_match (const char *, ...);
+ match gfc_match_iterator (gfc_iterator *, int);
+ match gfc_match_parens (void);
++match gfc_match_member_sep(gfc_symbol *);
+ 
+ /* Statement matchers.  */
+ match gfc_match_program (void);
+@@ -159,8 +160,12 @@ match gfc_match_generic (void);
+ match gfc_match_function_decl (void);
+ match gfc_match_entry (void);
+ match gfc_match_subroutine (void);
++match gfc_match_map (void);
++match gfc_match_union (void);
++match gfc_match_structure_decl (void);
+ match gfc_match_derived_decl (void);
+ match gfc_match_final_decl (void);
++match gfc_match_type (gfc_statement *);
+ 
+ match gfc_match_implicit_none (void);
+ match gfc_match_implicit (void);
+@@ -192,6 +197,7 @@ match gfc_match_value (void);
+ match gfc_match_volatile (void);
+ 
+ /* decl.c.  */
++match gfc_match_clist_expr (gfc_expr **, gfc_typespec *, bool);
+ 
+ /* Fortran 2003 c interop.
+    TODO: some of these should be moved to another file rather than decl.c */
+diff --git a/gcc/fortran/misc.c b/gcc/fortran/misc.c
+index cce599b..8e097e1 100644
+--- a/gcc/fortran/misc.c
++++ b/gcc/fortran/misc.c
+@@ -92,6 +92,9 @@ gfc_basic_typename (bt type)
+     case BT_HOLLERITH:
+       p = "HOLLERITH";
+       break;
++    case BT_UNION:
++      p = "UNION";
++      break;
+     case BT_DERIVED:
+       p = "DERIVED";
+       break;
+@@ -153,6 +156,9 @@ gfc_typename (gfc_typespec *ts)
+     case BT_HOLLERITH:
+       sprintf (buffer, "HOLLERITH");
+       break;
++    case BT_UNION:
++      sprintf (buffer, "UNION(%s)", ts->u.derived->name);
++      break;
+     case BT_DERIVED:
+       sprintf (buffer, "TYPE(%s)", ts->u.derived->name);
+       break;
+diff --git a/gcc/fortran/module.c b/gcc/fortran/module.c
+index 4fd0d88..379c390 100644
+--- a/gcc/fortran/module.c
++++ b/gcc/fortran/module.c
+@@ -406,8 +406,8 @@ resolve_fixups (fixup_t *f, void *gp)
+    to convert the symtree name of a derived-type to the symbol name or to
+    the name of the associated generic function.  */
+ 
+-static const char *
+-dt_lower_string (const char *name)
++const char *
++gfc_dt_lower_string (const char *name)
+ {
+   if (name[0] != (char) TOLOWER ((unsigned char) name[0]))
+     return gfc_get_string ("%c%s", (char) TOLOWER ((unsigned char) name[0]),
+@@ -421,8 +421,8 @@ dt_lower_string (const char *name)
+    symtree/symbol name of the associated generic function start with a lower-
+    case character.  */
+ 
+-static const char *
+-dt_upper_string (const char *name)
++const char *
++gfc_dt_upper_string (const char *name)
+ {
+   if (name[0] != (char) TOUPPER ((unsigned char) name[0]))
+     return gfc_get_string ("%c%s", (char) TOUPPER ((unsigned char) name[0]),
+@@ -724,7 +724,7 @@ find_use_name_n (const char *name, int *inst, bool interface)
+ 
+   /* For derived types.  */
+   if (name[0] != (char) TOLOWER ((unsigned char) name[0]))
+-    low_name = dt_lower_string (name);
++    low_name = gfc_dt_lower_string (name);
+ 
+   i = 0;
+   for (u = gfc_rename_list; u; u = u->next)
+@@ -753,7 +753,7 @@ find_use_name_n (const char *name, int *inst, bool interface)
+     {
+       if (u->local_name[0] == '\0')
+ 	return name;
+-      return dt_upper_string (u->local_name);
++      return gfc_dt_upper_string (u->local_name);
+     }
+ 
+   return (u->local_name[0] != '\0') ? u->local_name : name;
+@@ -881,8 +881,8 @@ add_true_name (gfc_symbol *sym)
+ 
+   t = XCNEW (true_name);
+   t->sym = sym;
+-  if (sym->attr.flavor == FL_DERIVED)
+-    t->name = dt_upper_string (sym->name);
++  if (gfc_fl_struct (sym->attr.flavor))
++    t->name = gfc_dt_upper_string (sym->name);
+   else
+     t->name = sym->name;
+ 
+@@ -903,8 +903,8 @@ build_tnt (gfc_symtree *st)
+   build_tnt (st->left);
+   build_tnt (st->right);
+ 
+-  if (st->n.sym->attr.flavor == FL_DERIVED)
+-    name = dt_upper_string (st->n.sym->name);
++  if (gfc_fl_struct (st->n.sym->attr.flavor))
++    name = gfc_dt_upper_string (st->n.sym->name);
+   else
+     name = st->n.sym->name;
+ 
+@@ -2219,6 +2219,7 @@ static const mstring bt_types[] = {
+     minit ("COMPLEX", BT_COMPLEX),
+     minit ("LOGICAL", BT_LOGICAL),
+     minit ("CHARACTER", BT_CHARACTER),
++    minit ("UNION", BT_UNION),
+     minit ("DERIVED", BT_DERIVED),
+     minit ("CLASS", BT_CLASS),
+     minit ("PROCEDURE", BT_PROCEDURE),
+@@ -2272,7 +2273,7 @@ mio_typespec (gfc_typespec *ts)
+ 
+   ts->type = MIO_NAME (bt) (ts->type, bt_types);
+ 
+-  if (ts->type != BT_DERIVED && ts->type != BT_CLASS)
++  if (!gfc_bt_struct (ts->type) && ts->type != BT_CLASS)
+     mio_integer (&ts->kind);
+   else
+     mio_symbol_ref (&ts->u.derived);
+@@ -3088,8 +3089,8 @@ fix_mio_expr (gfc_expr *e)
+       if (e->symtree->n.sym && check_unique_name (e->symtree->name))
+ 	{
+           const char *name = e->symtree->n.sym->name;
+-	  if (e->symtree->n.sym->attr.flavor == FL_DERIVED)
+-	    name = dt_upper_string (name);
++	  if (gfc_fl_struct (e->symtree->n.sym->attr.flavor))
++	    name = gfc_dt_upper_string (name);
+ 	  ns_st = gfc_find_symtree (gfc_current_ns->sym_root, name);
+ 	}
+ 
+@@ -3779,7 +3780,7 @@ mio_symbol (gfc_symbol *sym)
+   
+   mio_integer (&(sym->intmod_sym_id));
+ 
+-  if (sym->attr.flavor == FL_DERIVED)
++  if (gfc_fl_struct (sym->attr.flavor))
+     mio_integer (&(sym->hash_value));
+ 
+   mio_rparen ();
+@@ -4310,7 +4311,7 @@ load_needed (pointer_info *p)
+ 				 1, &ns->proc_name);
+ 
+       sym = gfc_new_symbol (p->u.rsym.true_name, ns);
+-      sym->name = dt_lower_string (p->u.rsym.true_name);
++      sym->name = gfc_dt_lower_string (p->u.rsym.true_name);
+       sym->module = gfc_get_string (p->u.rsym.module);
+       if (p->u.rsym.binding_label)
+ 	sym->binding_label = IDENTIFIER_POINTER (get_identifier 
+@@ -4322,6 +4323,12 @@ load_needed (pointer_info *p)
+   mio_symbol (sym);
+   sym->attr.use_assoc = 1;
+ 
++  /* Unliked derived types, a STRUCTURE may share names with other symbols.
++     We greedily converted the the symbol name to lowercase before we knew its
++     type, so now we must fix it. */
++  if (sym->attr.flavor == FL_STRUCT)
++    sym->name = gfc_dt_upper_string (sym->name);
++
+   /* Mark as only or rename for later diagnosis for explicitly imported
+      but not used warnings; don't mark internal symbols such as __vtab,
+      __def_init etc. Only mark them if they have been explicitly loaded.  */
+@@ -4521,7 +4528,7 @@ read_module (void)
+ 	 can be used in expressions in the module.  To avoid the module loading
+ 	 failing, we need to associate the module's component pointer indexes
+ 	 with the existing symbol's component pointers.  */
+-      if (sym->attr.flavor == FL_DERIVED)
++      if (gfc_fl_struct (sym->attr.flavor))
+ 	{
+ 	  gfc_component *c;
+ 
+@@ -4673,7 +4680,7 @@ read_module (void)
+ 		{
+ 		  info->u.rsym.sym = gfc_new_symbol (info->u.rsym.true_name,
+ 						     gfc_current_ns);
+-		  info->u.rsym.sym->name = dt_lower_string (info->u.rsym.true_name);
++		  info->u.rsym.sym->name = gfc_dt_lower_string (info->u.rsym.true_name);
+ 		  sym = info->u.rsym.sym;
+ 		  sym->module = gfc_get_string (info->u.rsym.module);
+ 
+@@ -5056,10 +5063,10 @@ write_symbol (int n, gfc_symbol *sym)
+ 
+   mio_integer (&n);
+ 
+-  if (sym->attr.flavor == FL_DERIVED)
++  if (gfc_fl_struct (sym->attr.flavor))
+     {
+       const char *name;
+-      name = dt_upper_string (sym->name);
++      name = gfc_dt_upper_string (sym->name);
+       mio_pool_string (&name);
+     }
+   else
+@@ -5870,7 +5877,7 @@ create_derived_type (const char *name, const char *modname,
+   sym->attr.function = 1;
+   sym->attr.generic = 1;
+ 
+-  gfc_get_sym_tree (dt_upper_string (sym->name),
++  gfc_get_sym_tree (gfc_dt_upper_string (sym->name),
+ 		    gfc_current_ns, &tmp_symtree, false);
+   dt_sym = tmp_symtree->n.sym;
+   dt_sym->name = gfc_get_string (sym->name);
+diff --git a/gcc/fortran/options.c b/gcc/fortran/options.c
+index 08f885a..09e0897 100644
+--- a/gcc/fortran/options.c
++++ b/gcc/fortran/options.c
+@@ -1125,7 +1125,14 @@ gfc_handle_option (size_t scode, const char *arg, int value,
+     case OPT_fcoarray_:
+       gfc_handle_coarray_option (arg);
+       break;
+ 
++    case OPT_fdec_structure:
++      gfc_option.flag_dec_structure = 1;
++      /* Fall-through: -fdec-structure implies -fdec-member-dot. */
++
++    case OPT_fdec_member_dot:
++      gfc_option.flag_dec_member_dot = 1;
++      break;
+     }
+ 
+   Fortran_handle_option_auto (&global_options, &global_options_set, 
+diff --git a/gcc/fortran/parse.c b/gcc/fortran/parse.c
+index 54449e0..7ec594e 100644
+--- a/gcc/fortran/parse.c
++++ b/gcc/fortran/parse.c
+@@ -229,6 +229,7 @@ decode_specification_statement (void)
+ 
+     case 's':
+       match ("save", gfc_match_save, ST_ATTR_DECL);
++      match ("structure", gfc_match_structure_decl, ST_STRUCTURE_DECL);
+       break;
+ 
+     case 't':
+@@ -457,6 +458,7 @@ decode_statement (void)
+       break;
+ 
+     case 'm':
++      match ("map", gfc_match_map, ST_MAP);
+       match ("module% procedure", gfc_match_modproc, ST_MODULE_PROC);
+       match ("module", gfc_match_module, ST_MODULE);
+       break;
+@@ -492,6 +494,8 @@ decode_statement (void)
+       break;
+ 
+     case 's':
++      // DEC extension: treat STRUCTURE /name/ ... as TYPE name ...
++      match ("structure", gfc_match_structure_decl, ST_STRUCTURE_DECL);
+       match ("sequence", gfc_match_eos, ST_SEQUENCE);
+       match ("stop", gfc_match_stop, ST_STOP);
+       match ("save", gfc_match_save, ST_ATTR_DECL);
+@@ -507,6 +511,7 @@ decode_statement (void)
+       break;
+ 
+     case 'u':
++      match ("union", gfc_match_union, ST_UNION);
+       match ("unlock", gfc_match_unlock, ST_UNLOCK);
+       break;
+ 
+@@ -1223,6 +1228,68 @@ gfc_enclosing_unit (gfc_compile_state * result)
+   return NULL;
+ }
+ 
++/* Translate a compile state to an ascii string. */
++
++const char *
++gfc_ascii_comp_state(gfc_compile_state c)
++{
++    const char *p = "NONE";
++    switch(c) {
++    case COMP_PROGRAM:
++        p = "PROGRAM"; break;
++    case COMP_MODULE:
++        p = "MODULE"; break;
++    case COMP_SUBROUTINE:
++        p = "SUBROUTINE"; break;
++    case COMP_FUNCTION:
++        p = "FUNCTION"; break;
++    case COMP_BLOCK_DATA:
++        p = "BLOCK DATA"; break;
++    case COMP_INTERFACE:
++        p = "INTERFACE"; break;
++    case COMP_DERIVED:
++        p = "DERIVED"; break;
++    case COMP_DERIVED_CONTAINS:
++        p = "DERIVED CONTAINS"; break;
++    case COMP_UNION:
++        p = "UNION"; break;
++    case COMP_MAP:
++        p = "MAP"; break;
++    case COMP_STRUCTURE:
++        p = "STRUCTURE"; break;
++    case COMP_BLOCK:
++        p = "BLOCK"; break;
++    case COMP_ASSOCIATE:
++        p = "ASSOCIATE"; break;
++    case COMP_IF:
++        p = "IF"; break;
++    case COMP_DO:
++        p = "DO"; break;
++    case COMP_SELECT:
++        p = "SELECT"; break;
++    case COMP_FORALL:
++        p = "FORALL"; break;
++    case COMP_WHERE:
++        p = "WHERE"; break;
++    case COMP_CONTAINS:
++        p = "CONTAINS"; break;
++    case COMP_ENUM:
++        p = "ENUM"; break;
++    case COMP_SELECT_TYPE:
++        p = "SELECT TYPE"; break;
++    case COMP_OMP_STRUCTURED_BLOCK:
++        p = "OMP STRUCTURED BLOCK"; break;
++    case COMP_CRITICAL:
++        p = "CRITICAL"; break;
++    case COMP_DO_CONCURRENT:
++        p = "CONCURRENT DO"; break;
++    case COMP_NONE:
++    default:
++        break;
++    }
++    return p;
++}
++
+ 
+ /* Translate a statement enum to a string.  */
+ 
+@@ -1287,6 +1354,15 @@ gfc_ascii_statement (gfc_statement st)
+     case ST_DEALLOCATE:
+       p = "DEALLOCATE";
+       break;
++    case ST_MAP:
++      p = "MAP";
++      break;
++    case ST_UNION:
++      p = "UNION";
++      break;
++    case ST_STRUCTURE_DECL:
++      p = "STRUCTURE";
++      break;
+     case ST_DERIVED_DECL:
+       p = _("derived type declaration");
+       break;
+@@ -1347,6 +1423,15 @@ gfc_ascii_statement (gfc_statement st)
+     case ST_END_WHERE:
+       p = "END WHERE";
+       break;
++    case ST_END_STRUCTURE:
++      p = "END STRUCTURE";
++      break;
++    case ST_END_UNION:
++      p = "END UNION";
++      break;
++    case ST_END_MAP:
++      p = "END MAP";
++      break;
+     case ST_END_TYPE:
+       p = "END TYPE";
+       break;
+@@ -1883,6 +1968,7 @@ verify_st_order (st_state *p, gfc_statement st, bool silent)
+ 
+     case ST_PUBLIC:
+     case ST_PRIVATE:
++    case ST_STRUCTURE_DECL:
+     case ST_DERIVED_DECL:
+     case_decl:
+       if (p->state >= ORDER_EXEC)
+@@ -2076,6 +2162,349 @@ error:
+   return error_flag;
+ }
+ 
++/* Set attributes for the parent symbol (gfc_symbol*)data based on the
++   attributes of a component, and raise errors if conflicting attributes
++   are found for the component. */
++
++static void
++check_component (gfc_component *c, gfc_symbol *sym, gfc_component **lockp)
++{
++  gfc_component *lock_comp = NULL;
++  bool coarray, lock_type, allocatable, pointer;
++  coarray = lock_type = allocatable = pointer = false;
++
++  if (lockp) lock_comp = *lockp;
++
++  /* Look for allocatable components.  */
++  if (c->attr.allocatable
++      || (c->ts.type == BT_CLASS && c->attr.class_ok
++          && CLASS_DATA (c)->attr.allocatable)
++      || (c->ts.type == BT_DERIVED && !c->attr.pointer
++          && c->ts.u.derived->attr.alloc_comp))
++    {
++      allocatable = true;
++      sym->attr.alloc_comp = 1;
++    }
++
++  /* Look for pointer components.  */
++  if (c->attr.pointer
++      || (c->ts.type == BT_CLASS && c->attr.class_ok
++          && CLASS_DATA (c)->attr.class_pointer)
++      || (c->ts.type == BT_DERIVED && c->ts.u.derived->attr.pointer_comp))
++    {
++      pointer = true;
++      sym->attr.pointer_comp = 1;
++    }
++
++  /* Look for procedure pointer components.  */
++  if (c->attr.proc_pointer
++      || (c->ts.type == BT_DERIVED
++          && c->ts.u.derived->attr.proc_pointer_comp))
++    sym->attr.proc_pointer_comp = 1;
++
++  /* Looking for coarray components.  */
++  if (c->attr.codimension
++      || (c->ts.type == BT_CLASS && c->attr.class_ok
++          && CLASS_DATA (c)->attr.codimension))
++    {
++      coarray = true;
++      sym->attr.coarray_comp = 1;
++    }
++ 
++  if (c->ts.type == BT_DERIVED && c->ts.u.derived->attr.coarray_comp)
++    {
++      coarray = true;
++      if (!pointer && !allocatable)
++        sym->attr.coarray_comp = 1;
++    }
++
++  /* Looking for lock_type components.  */
++  if ((c->ts.type == BT_DERIVED
++          && c->ts.u.derived->from_intmod == INTMOD_ISO_FORTRAN_ENV
++          && c->ts.u.derived->intmod_sym_id == ISOFORTRAN_LOCK_TYPE)
++      || (c->ts.type == BT_CLASS && c->attr.class_ok
++          && CLASS_DATA (c)->ts.u.derived->from_intmod
++             == INTMOD_ISO_FORTRAN_ENV
++          && CLASS_DATA (c)->ts.u.derived->intmod_sym_id
++             == ISOFORTRAN_LOCK_TYPE)
++      || (c->ts.type == BT_DERIVED && c->ts.u.derived->attr.lock_comp
++          && !allocatable && !pointer))
++    {
++      lock_type = 1;
++      lock_comp = c;
++      sym->attr.lock_comp = 1;
++    }
++
++  /* Check for F2008, C1302 - and recall that pointers may not be coarrays
++     (5.3.14) and that subobjects of coarray are coarray themselves (2.4.7),
++     unless there are nondirect [allocatable or pointer] components
++     involved (cf. 1.3.33.1 and 1.3.33.3).  */
++
++  if (pointer && !coarray && lock_type)
++    gfc_error ("Component %s at %L of type LOCK_TYPE must have a "
++               "codimension or be a subcomponent of a coarray, "
++               "which is not possible as the component has the "
++               "pointer attribute", c->name, &c->loc);
++  else if (pointer && !coarray && c->ts.type == BT_DERIVED
++           && c->ts.u.derived->attr.lock_comp)
++    gfc_error ("Pointer component %s at %L has a noncoarray subcomponent "
++               "of type LOCK_TYPE, which must have a codimension or be a "
++               "subcomponent of a coarray", c->name, &c->loc);
++
++  if (lock_type && allocatable && !coarray)
++    gfc_error ("Allocatable component %s at %L of type LOCK_TYPE must have "
++               "a codimension", c->name, &c->loc);
++  else if (lock_type && allocatable && c->ts.type == BT_DERIVED
++           && c->ts.u.derived->attr.lock_comp)
++    gfc_error ("Allocatable component %s at %L must have a codimension as "
++               "it has a noncoarray subcomponent of type LOCK_TYPE",
++               c->name, &c->loc);
++
++  if (sym->attr.coarray_comp && !coarray && lock_type)
++    gfc_error ("Noncoarray component %s at %L of type LOCK_TYPE or with "
++               "subcomponent of type LOCK_TYPE must have a codimension or "
++               "be a subcomponent of a coarray. (Variables of type %s may "
++               "not have a codimension as already a coarray "
++               "subcomponent exists)", c->name, &c->loc, sym->name);
++
++  if (sym->attr.lock_comp && coarray && !lock_type)
++    gfc_error ("Noncoarray component %s at %L of type LOCK_TYPE or with "
++               "subcomponent of type LOCK_TYPE must have a codimension or "
++               "be a subcomponent of a coarray. (Variables of type %s may "
++               "not have a codimension as %s at %L has a codimension or a "
++               "coarray subcomponent)", lock_comp->name, &lock_comp->loc,
++               sym->name, c->name, &c->loc);
++
++  /* Look for private components.  */
++  if (sym->component_access == ACCESS_PRIVATE
++      || c->attr.access == ACCESS_PRIVATE
++      || (c->ts.type == BT_DERIVED && c->ts.u.derived->attr.private_comp))
++    sym->attr.private_comp = 1;
++
++  if (lockp) *lockp = lock_comp;
++}
++
++static void parse_map (void);
++
++/* Parse a union component definition within a structure/derived-type 
++   definition. */
++
++static void
++parse_union (void)
++{
++    int compiling;
++    gfc_statement st;
++    gfc_state_data s;
++    gfc_component *c;
++    gfc_symbol *un;
++
++    accept_statement(ST_UNION);
++    push_state (&s, COMP_UNION, gfc_new_block);
++    un = gfc_new_block;
++
++    compiling = 1;
++
++    while (compiling)
++    {
++      st = next_statement ();
++      /* Only MAP declarations valid within a union. */
++      switch (st)
++        {
++        case ST_NONE:
++          unexpected_eof ();
++
++        case ST_MAP:
++          accept_statement (ST_MAP);
++          parse_map ();
++          /* Add a component to the union for each map. */
++          if (gfc_add_component (un, gfc_new_block->name, &c) == FAILURE)
++          {
++            gfc_internal_error ("failed to create map component '%s'", 
++                gfc_new_block->name);
++            reject_statement ();
++            return;
++          }
++          c->ts.type = BT_DERIVED;
++          c->ts.u.derived = gfc_new_block;
++          break;
++
++        case ST_END_UNION:
++          compiling = 0;
++          accept_statement (ST_END_UNION);
++          break;
++
++        default:
++          gfc_error ("Unexpected statement at %C; only MAP blocks are valid in"
++                     " a UNION block");
++          reject_statement ();
++          break;
++        }
++    }
++
++    for (c = un->components; c; c = c->next)
++      check_component (c, un, NULL);
++
++    /* Add the union as a component in its parent structure. */
++    pop_state ();
++    if (gfc_add_component (gfc_current_block (), un->name, &c) == FAILURE)
++    {
++      gfc_internal_error ("failed to create union component '%s'", un->name);
++      reject_statement ();
++      return;
++    }
++    c->ts.type = BT_UNION;
++    c->ts.u.derived = un;
++
++    un->attr.zero_comp = un->components == NULL;
++}
++
++/* Parse a structure definition. */
++
++static void
++parse_structure (void)
++{ 
++    int compiling_type;
++    gfc_statement st;
++    gfc_state_data s;
++    gfc_symbol *sym;
++    gfc_component *c;
++
++    accept_statement(ST_STRUCTURE_DECL);
++    push_state (&s, COMP_STRUCTURE, gfc_new_block);
++
++    gfc_new_block->component_access = ACCESS_PUBLIC;
++    compiling_type = 1;
++
++    while (compiling_type)
++    {
++      st = next_statement ();
++      switch (st)
++        {
++        case ST_NONE:
++          unexpected_eof ();
++          break;
++
++        /* Nested structure declarations should be captured as ST_DATA_DECL. */
++        case ST_STRUCTURE_DECL:
++          /* Let a more specific error take over. */
++          if (gfc_error_check () == 0)
++            gfc_error ("Syntax error in nested structure declaration at %C");
++          reject_statement ();
++          /* Skip the rest of this statement. */
++          gfc_error_recovery ();
++          break;
++
++        case ST_UNION:
++          accept_statement (ST_UNION);
++          parse_union ();
++          break;
++
++        case ST_DATA_DECL:
++          accept_statement (ST_DATA_DECL);
++          /* The data declaration was a nested/ad-hoc STRUCTURE field */
++          if (gfc_new_block && gfc_new_block != gfc_current_block ()
++                            && gfc_new_block->attr.flavor == FL_STRUCT)
++              parse_structure ();
++          break;
++
++        case ST_END_STRUCTURE:
++          compiling_type = 0;
++          accept_statement (ST_END_STRUCTURE);
++          break;
++
++        default:
++          unexpected_statement (st);
++          break;
++        }
++    }
++
++    /* need to verify that all fields of the derived type are
++    * interoperable with C if the type is declared to be bind(c)
++    */
++    sym = gfc_current_block ();
++    for (c = sym->components; c; c = c->next)
++      check_component (c, sym, NULL);
++
++    sym->attr.zero_comp = sym->components == NULL;
++
++    pop_state ();
++
++}
++
++/* Parse a map definition within a union. Similar to a structure definition
++   itself. */
++
++static void
++parse_map (void)
++{
++    int compiling_type;
++    gfc_statement st;
++    gfc_state_data s;
++    gfc_symbol *sym;
++    gfc_component *c;
++
++    accept_statement(ST_MAP);
++    push_state (&s, COMP_MAP, gfc_new_block);
++
++    gfc_new_block->component_access = ACCESS_PUBLIC;
++    compiling_type = 1;
++
++    while (compiling_type)
++    {
++      st = next_statement ();
++      switch (st)
++        {
++        case ST_NONE:
++          unexpected_eof ();
++
++        /* Nested structure declarations should be captured as ST_DATA_DECL. */
++        case ST_STRUCTURE_DECL:
++          /* Let a more specific error make it to decode_statement(). */
++          if (gfc_error_check () == 0)
++            gfc_error ("Syntax error in nested structure declaration at %C");
++          reject_statement ();
++          /* Skip the rest of this statement. */
++          gfc_error_recovery ();
++          break;
++
++        case ST_UNION:
++          accept_statement (ST_UNION);
++          parse_union ();
++          break;
++
++        case ST_DATA_DECL:
++          accept_statement (ST_DATA_DECL);
++          /* The data declaration was a nested/ad-hoc STRUCTURE field */
++          if (gfc_new_block && gfc_new_block != gfc_current_block ()
++                            && gfc_new_block->attr.flavor == FL_STRUCT)
++              parse_structure ();
++          break;
++
++        case ST_END_MAP:
++          compiling_type = 0;
++          accept_statement (ST_END_MAP);
++          break;
++
++        default:
++          unexpected_statement (st);
++          break;
++        }
++    }
++
++    /* need to verify that all fields of the derived type are
++    * interoperable with C if the type is declared to be bind(c)
++    */
++    sym = gfc_current_block ();
++    for (c = sym->components; c; c = c->next)
++      check_component (c, sym, NULL);
++
++    sym->attr.zero_comp = sym->components == NULL;
++
++    /* So parse_union can add this structure to its list of maps */
++    gfc_new_block = gfc_current_block ();
++
++    pop_state ();
++}
+ 
+ /* Parse a derived type.  */
+ 
+@@ -2193,119 +2622,9 @@ endType:
+    */
+   sym = gfc_current_block ();
+   for (c = sym->components; c; c = c->next)
+-    {
+-      bool coarray, lock_type, allocatable, pointer;
+-      coarray = lock_type = allocatable = pointer = false;
+-
+-      /* Look for allocatable components.  */
+-      if (c->attr.allocatable
+-	  || (c->ts.type == BT_CLASS && c->attr.class_ok
+-	      && CLASS_DATA (c)->attr.allocatable)
+-	  || (c->ts.type == BT_DERIVED && !c->attr.pointer
+-	      && c->ts.u.derived->attr.alloc_comp))
+-	{
+-	  allocatable = true;
+-	  sym->attr.alloc_comp = 1;
+-	}
+-
+-      /* Look for pointer components.  */
+-      if (c->attr.pointer
+-	  || (c->ts.type == BT_CLASS && c->attr.class_ok
+-	      && CLASS_DATA (c)->attr.class_pointer)
+-	  || (c->ts.type == BT_DERIVED && c->ts.u.derived->attr.pointer_comp))
+-	{
+-	  pointer = true;
+-	  sym->attr.pointer_comp = 1;
+-	}
++    check_component (c, sym, &lock_comp);
+ 
+-      /* Look for procedure pointer components.  */
+-      if (c->attr.proc_pointer
+-	  || (c->ts.type == BT_DERIVED
+-	      && c->ts.u.derived->attr.proc_pointer_comp))
+-	sym->attr.proc_pointer_comp = 1;
+-
+-      /* Looking for coarray components.  */
+-      if (c->attr.codimension
+-	  || (c->ts.type == BT_CLASS && c->attr.class_ok
+-	      && CLASS_DATA (c)->attr.codimension))
+-	{
+-	  coarray = true;
+-	  sym->attr.coarray_comp = 1;
+-	}
+-     
+-      if (c->ts.type == BT_DERIVED && c->ts.u.derived->attr.coarray_comp)
+-	{
+-	  coarray = true;
+-	  if (!pointer && !allocatable)
+-	    sym->attr.coarray_comp = 1;
+-	}
+-
+-      /* Looking for lock_type components.  */
+-      if ((c->ts.type == BT_DERIVED
+-	      && c->ts.u.derived->from_intmod == INTMOD_ISO_FORTRAN_ENV
+-	      && c->ts.u.derived->intmod_sym_id == ISOFORTRAN_LOCK_TYPE)
+-	  || (c->ts.type == BT_CLASS && c->attr.class_ok
+-	      && CLASS_DATA (c)->ts.u.derived->from_intmod
+-		 == INTMOD_ISO_FORTRAN_ENV
+-	      && CLASS_DATA (c)->ts.u.derived->intmod_sym_id
+-		 == ISOFORTRAN_LOCK_TYPE)
+-	  || (c->ts.type == BT_DERIVED && c->ts.u.derived->attr.lock_comp
+-	      && !allocatable && !pointer))
+-	{
+-	  lock_type = 1;
+-	  lock_comp = c;
+-	  sym->attr.lock_comp = 1;
+-	}
+-
+-      /* Check for F2008, C1302 - and recall that pointers may not be coarrays
+-	 (5.3.14) and that subobjects of coarray are coarray themselves (2.4.7),
+-	 unless there are nondirect [allocatable or pointer] components
+-	 involved (cf. 1.3.33.1 and 1.3.33.3).  */
+-
+-      if (pointer && !coarray && lock_type)
+-	gfc_error ("Component %s at %L of type LOCK_TYPE must have a "
+-		   "codimension or be a subcomponent of a coarray, "
+-		   "which is not possible as the component has the "
+-		   "pointer attribute", c->name, &c->loc);
+-      else if (pointer && !coarray && c->ts.type == BT_DERIVED
+-	       && c->ts.u.derived->attr.lock_comp)
+-	gfc_error ("Pointer component %s at %L has a noncoarray subcomponent "
+-		   "of type LOCK_TYPE, which must have a codimension or be a "
+-		   "subcomponent of a coarray", c->name, &c->loc);
+-
+-      if (lock_type && allocatable && !coarray)
+-	gfc_error ("Allocatable component %s at %L of type LOCK_TYPE must have "
+-		   "a codimension", c->name, &c->loc);
+-      else if (lock_type && allocatable && c->ts.type == BT_DERIVED
+-	       && c->ts.u.derived->attr.lock_comp)
+-	gfc_error ("Allocatable component %s at %L must have a codimension as "
+-		   "it has a noncoarray subcomponent of type LOCK_TYPE",
+-		   c->name, &c->loc);
+-
+-      if (sym->attr.coarray_comp && !coarray && lock_type)
+-	gfc_error ("Noncoarray component %s at %L of type LOCK_TYPE or with "
+-		   "subcomponent of type LOCK_TYPE must have a codimension or "
+-		   "be a subcomponent of a coarray. (Variables of type %s may "
+-		   "not have a codimension as already a coarray "
+-		   "subcomponent exists)", c->name, &c->loc, sym->name);
+-
+-      if (sym->attr.lock_comp && coarray && !lock_type)
+-	gfc_error ("Noncoarray component %s at %L of type LOCK_TYPE or with "
+-		   "subcomponent of type LOCK_TYPE must have a codimension or "
+-		   "be a subcomponent of a coarray. (Variables of type %s may "
+-		   "not have a codimension as %s at %L has a codimension or a "
+-		   "coarray subcomponent)", lock_comp->name, &lock_comp->loc,
+-		   sym->name, c->name, &c->loc);
+-
+-      /* Look for private components.  */
+-      if (sym->component_access == ACCESS_PRIVATE
+-	  || c->attr.access == ACCESS_PRIVATE
+-	  || (c->ts.type == BT_DERIVED && c->ts.u.derived->attr.private_comp))
+-	sym->attr.private_comp = 1;
+-    }
+-
+-  if (!seen_component)
+-    sym->attr.zero_comp = 1;
++  sym->attr.zero_comp = !seen_component;
+ 
+   pop_state ();
+ }
+@@ -2688,6 +3007,7 @@ loop:
+     case ST_PARAMETER:
+     case ST_PUBLIC:
+     case ST_PRIVATE:
++    case ST_STRUCTURE_DECL:
+     case ST_DERIVED_DECL:
+     case_decl:
+ declSt:
+@@ -2704,6 +3024,10 @@ declSt:
+ 	  parse_interface ();
+ 	  break;
+ 
++        case ST_STRUCTURE_DECL:
++          parse_structure ();
++          break;
++
+ 	case ST_DERIVED_DECL:
+ 	  parse_derived ();
+ 	  break;
+@@ -3948,9 +4272,9 @@ gfc_fixup_sibling_symbols (gfc_symbol *sym, gfc_namespace *siblings)
+       if (!st || (st->n.sym->attr.dummy && ns == st->n.sym->ns))
+ 	goto fixup_contained;
+ 
+-      if ((st->n.sym->attr.flavor == FL_DERIVED
++      if ((gfc_fl_struct (st->n.sym->attr.flavor)
+ 	   && sym->attr.generic && sym->attr.function)
+-	  ||(sym->attr.flavor == FL_DERIVED
++	  ||(gfc_fl_struct (sym->attr.flavor)
+ 	     && st->n.sym->attr.generic && st->n.sym->attr.function))
+ 	goto fixup_contained;
+ 
+diff --git a/gcc/fortran/parse.h b/gcc/fortran/parse.h
+index dbe3c49..a8c9cf9 100644
+--- a/gcc/fortran/parse.h
++++ b/gcc/fortran/parse.h
+@@ -27,6 +27,7 @@ typedef enum
+ {
+   COMP_NONE, COMP_PROGRAM, COMP_MODULE, COMP_SUBROUTINE, COMP_FUNCTION,
+   COMP_BLOCK_DATA, COMP_INTERFACE, COMP_DERIVED, COMP_DERIVED_CONTAINS,
++  COMP_STRUCTURE, COMP_UNION, COMP_MAP,
+   COMP_BLOCK, COMP_ASSOCIATE, COMP_IF,
+   COMP_DO, COMP_SELECT, COMP_FORALL, COMP_WHERE, COMP_CONTAINS, COMP_ENUM,
+   COMP_SELECT_TYPE, COMP_OMP_STRUCTURED_BLOCK, COMP_CRITICAL, COMP_DO_CONCURRENT
+@@ -59,10 +60,15 @@ extern gfc_state_data *gfc_state_stack;
+ #define gfc_current_block() (gfc_state_stack->sym)
+ #define gfc_current_state() (gfc_state_stack->state)
+ 
++/* STRUCTURE and TYPE are treated similarly, so these are common checks. */
++#define gfc_comp_is_derived(s) \
++    (((s) == COMP_DERIVED) || ((s) == COMP_STRUCTURE) || ((s) == COMP_MAP))
++
+ int gfc_check_do_variable (gfc_symtree *);
+ gfc_try gfc_find_state (gfc_compile_state);
+ gfc_state_data *gfc_enclosing_unit (gfc_compile_state *);
+ const char *gfc_ascii_statement (gfc_statement);
++const char *gfc_ascii_comp_state (gfc_compile_state);
+ match gfc_match_enum (void);
+ match gfc_match_enumerator_def (void);
+ void gfc_free_enum_history (void);
+diff --git a/gcc/fortran/primary.c b/gcc/fortran/primary.c
+index 3e18e05..cd25789 100644
+--- a/gcc/fortran/primary.c
++++ b/gcc/fortran/primary.c
+@@ -1840,11 +1840,12 @@ gfc_match_varspec (gfc_expr *primary, int equiv_flag, bool sub_flag,
+ 		   bool ppc_arg)
+ {
+   char name[GFC_MAX_SYMBOL_LEN + 1];
+-  gfc_ref *substring, *tail;
++  gfc_ref *substring, *tail, *tmp;
+   gfc_component *component;
+   gfc_symbol *sym = primary->symtree->n.sym;
+   match m;
+   bool unknown;
++  char sep;
+ 
+   tail = NULL;
+ 
+@@ -1925,25 +1926,30 @@ gfc_match_varspec (gfc_expr *primary, int equiv_flag, bool sub_flag,
+   if (equiv_flag)
+     return MATCH_YES;
+ 
+-  if (sym->ts.type == BT_UNKNOWN && gfc_peek_structure_access_operator ()
++  sep = gfc_peek_ascii_char ();
++  m = gfc_match_member_sep (sym);
++  if(m == MATCH_ERROR)
++      return MATCH_ERROR;
++
++  if (sym->ts.type == BT_UNKNOWN && m == MATCH_YES
+       && gfc_get_default_type (sym->name, sym->ns)->type == BT_DERIVED)
+     gfc_set_default_type (sym, 0, sym->ns);
+ 
+-  if (sym->ts.type == BT_UNKNOWN && gfc_match_char('%') == MATCH_YES)
++  if (sym->ts.type == BT_UNKNOWN && m == MATCH_YES)
+     {
+       gfc_error ("Symbol '%s' at %C has no IMPLICIT type", sym->name);
+       return MATCH_ERROR;
+     }
+   else if ((sym->ts.type != BT_DERIVED && sym->ts.type != BT_CLASS)
+-	   && gfc_match_char ('%') == MATCH_YES)
++          && m == MATCH_YES)
+     {
+-      gfc_error ("Unexpected '%%' for nonderived-type variable '%s' at %C",
+-		 sym->name);
++      gfc_error ("Unexpected '%c' for nonderived-type variable "
++                 "'%s' at %C", sep, sym->name);
+       return MATCH_ERROR;
+     }
+ 
+   if ((sym->ts.type != BT_DERIVED && sym->ts.type != BT_CLASS)
+-      || gfc_match_char ('%') != MATCH_YES)
++      || m != MATCH_YES)
+     goto check_substring;
+ 
+   sym = sym->ts.u.derived;
+@@ -2012,15 +2018,20 @@ gfc_match_varspec (gfc_expr *primary, int equiv_flag, bool sub_flag,
+ 	  break;
+ 	}
+ 
+-      component = gfc_find_component (sym, name, false, false);
++      component = gfc_find_component (sym, name, false, false, &tmp);
+       if (component == NULL)
+-	return MATCH_ERROR;
++        return MATCH_ERROR;
+ 
+-      tail = extend_ref (primary, tail);
+-      tail->type = REF_COMPONENT;
++      /* Extend the reference chain through the determined ref. */
++      if (primary->ref == NULL)
++        primary->ref = tmp;
++      else
++        tail->next = tmp;
+ 
+-      tail->u.c.component = component;
+-      tail->u.c.sym = sym;
++      /* The reference chain may be longer than one hop for union
++         subcomponents; find the new tail. */
++      for (tail = tmp; tail->next; tail = tail->next)
++        ;
+ 
+       primary->ts = component->ts;
+ 
+@@ -2071,7 +2082,7 @@ gfc_match_varspec (gfc_expr *primary, int equiv_flag, bool sub_flag,
+ 	}
+ 
+       if ((component->ts.type != BT_DERIVED && component->ts.type != BT_CLASS)
+-	  || gfc_match_structure_access_operator () != MATCH_YES)
++	  || gfc_match_member_sep (component->ts.u.derived) != MATCH_YES)
+ 	break;
+ 
+       sym = component->ts.u.derived;
+@@ -2079,7 +2090,7 @@ gfc_match_varspec (gfc_expr *primary, int equiv_flag, bool sub_flag,
+ 
+ check_substring:
+   unknown = false;
+-  if (primary->ts.type == BT_UNKNOWN && sym->attr.flavor != FL_DERIVED)
++  if (primary->ts.type == BT_UNKNOWN && !gfc_fl_struct (sym->attr.flavor))
+     {
+       if (gfc_get_default_type (sym->name, sym->ns)->type == BT_CHARACTER)
+        {
+@@ -2481,11 +2492,11 @@ gfc_convert_to_structure_constructor (gfc_expr *e, gfc_symbol *sym, gfc_expr **c
+       /* Find the current component in the structure definition and check
+ 	     its access is not private.  */
+       if (comp)
+-	this_comp = gfc_find_component (sym, comp->name, false, false);
++	this_comp = gfc_find_component (sym, comp->name, false, false, NULL);
+       else
+ 	{
+ 	  this_comp = gfc_find_component (sym, (const char *)comp_tail->name,
+-					  false, false);
++					  false, false, NULL);
+ 	  comp = NULL; /* Reset needed!  */
+ 	}
+ 
+@@ -2529,7 +2540,7 @@ gfc_convert_to_structure_constructor (gfc_expr *e, gfc_symbol *sym, gfc_expr **c
+           if (comp && comp == sym->components
+                 && sym->attr.extension
+ 		&& comp_tail->val
+-                && (comp_tail->val->ts.type != BT_DERIVED
++                && (!gfc_bt_struct (comp_tail->val->ts.type)
+                       ||
+                     comp_tail->val->ts.u.derived != this_comp->ts.u.derived))
+             {
+@@ -2630,7 +2641,7 @@ gfc_match_structure_constructor (gfc_symbol *sym, gfc_expr **result)
+   e->symtree = symtree;
+   e->expr_type = EXPR_FUNCTION;
+ 
+-  gcc_assert (sym->attr.flavor == FL_DERIVED
++  gcc_assert (gfc_fl_struct (sym->attr.flavor)
+ 	      && symtree->n.sym->attr.flavor == FL_PROCEDURE);
+   e->value.function.esym = sym;
+   e->symtree->n.sym->attr.generic = 1;
+@@ -2719,18 +2730,43 @@ gfc_match_rvalue (gfc_expr **result)
+   bool implicit_char;
+   gfc_ref *ref;
+ 
+-  m = gfc_match_name (name);
+-  if (m != MATCH_YES)
+-    return m;
++  m = MATCH_NO;
++  if (gfc_option.flag_loc_rval)
++  {
++    /* Let %LOC() act as a valid rvalue; treat it like GFC_ISYM_LOC */
++    m = gfc_match ("%%loc");
++    if (m == MATCH_YES)
++        strcpy (name, "loc");
++  }
+ 
+-  if (gfc_find_state (COMP_INTERFACE) == SUCCESS
+-      && !gfc_current_ns->has_import_set)
+-    i = gfc_get_sym_tree (name, NULL, &symtree, false);
+-  else
+-    i = gfc_get_ha_sym_tree (name, &symtree);
++  if (m != MATCH_YES)
++  {
++      m = gfc_match_name (name);
++      if (m != MATCH_YES)
++        return m;
++  }
+ 
++  /* Check if the symbol exists first */
++  i = gfc_find_sym_tree (name, NULL, 1, &symtree);
+   if (i)
+     return MATCH_ERROR;
++  /* If not, we do not create it if there is a corresponding structure decl */
++  if (!symtree)
++  {
++    i = gfc_find_sym_tree (gfc_dt_upper_string (name), NULL, 1, &symtree);
++    if (i)
++      return MATCH_ERROR;
++  }
++  if (!symtree || symtree->n.sym->attr.flavor != FL_STRUCT)
++  {
++    if (gfc_find_state (COMP_INTERFACE) == SUCCESS
++        && !gfc_current_ns->has_import_set)
++      i = gfc_get_sym_tree (name, NULL, &symtree, false);
++    else
++      i = gfc_get_ha_sym_tree (name, &symtree);
++    if (i)
++      return MATCH_ERROR;
++  }
+ 
+   sym = symtree->n.sym;
+   e = NULL;
+@@ -2842,6 +2878,7 @@ gfc_match_rvalue (gfc_expr **result)
+ 
+       break;
+ 
++    case FL_STRUCT:
+     case FL_DERIVED:
+       sym = gfc_use_derived (sym);
+       if (sym == NULL)
+@@ -2982,10 +3019,12 @@ gfc_match_rvalue (gfc_expr **result)
+ 	 via an IMPLICIT statement.  This can't wait for the
+ 	 resolution phase.  */
+ 
+-      if (gfc_peek_structure_access_operator ()
++      old_loc = gfc_current_locus;
++      if (gfc_match_member_sep (sym) == MATCH_YES
+ 	  && sym->ts.type == BT_UNKNOWN
+ 	  && gfc_get_default_type (sym->name, sym->ns)->type == BT_DERIVED)
+ 	gfc_set_default_type (sym, 0, sym->ns);
++      gfc_current_locus = old_loc;
+ 
+       /* If the symbol has a (co)dimension attribute, the expression is a
+ 	 variable.  */
+@@ -3141,13 +3180,17 @@ gfc_match_rvalue (gfc_expr **result)
+       break;
+ 
+     generic_function:
+-      gfc_get_sym_tree (name, NULL, &symtree, false);	/* Can't fail */
++      gfc_find_sym_tree (name, NULL, 1, &symtree);
++      if (!symtree)
++        gfc_find_sym_tree (gfc_dt_upper_string (name), NULL, 1, &symtree);
++      if (!symtree || symtree->n.sym->attr.flavor != FL_STRUCT)
++        gfc_get_sym_tree (name, NULL, &symtree, false); /* Can't fail */
+ 
+       e = gfc_get_expr ();
+       e->symtree = symtree;
+       e->expr_type = EXPR_FUNCTION;
+ 
+-      if (sym->attr.flavor == FL_DERIVED)
++      if (gfc_fl_struct (sym->attr.flavor))
+ 	{
+ 	  e->value.function.esym = sym;
+ 	  e->symtree->n.sym->attr.generic = 1;
+@@ -3187,10 +3230,10 @@ gfc_match_rvalue (gfc_expr **result)
+ static match
+ match_variable (gfc_expr **result, int equiv_flag, int host_flag)
+ {
+-  gfc_symbol *sym;
++  gfc_symbol *sym, *dt_sym;
+   gfc_symtree *st;
+   gfc_expr *expr;
+-  locus where;
++  locus where, old_loc;
+   match m;
+ 
+   /* Since nothing has any business being an lvalue in a module
+@@ -3220,6 +3263,17 @@ match_variable (gfc_expr **result, int equiv_flag, int host_flag)
+   sym->attr.implied_index = 0;
+ 
+   gfc_set_sym_referenced (sym);
++
++  /* Check for generic symbols representing derived or structure types. */
++  if (sym->attr.flavor == FL_PROCEDURE && sym->generic
++      && (dt_sym = gfc_find_dt_in_generic (sym)))
++  {
++    if (dt_sym->attr.flavor == FL_DERIVED)
++      gfc_error ("Derived type '%s' cannot be used as a variable at %C",
++                 sym->name);
++    return MATCH_ERROR;
++  }
++
+   switch (sym->attr.flavor)
+     {
+     case FL_VARIABLE:
+@@ -3305,10 +3359,12 @@ match_variable (gfc_expr **result, int equiv_flag, int host_flag)
+ 	implicit_ns = gfc_current_ns;
+       else
+ 	implicit_ns = sym->ns;
+-      if (gfc_peek_structure_access_operator ()
++      old_loc = gfc_current_locus;
++      if (gfc_match_member_sep (sym) == MATCH_YES
+ 	  && sym->ts.type == BT_UNKNOWN
+ 	  && gfc_get_default_type (sym->name, implicit_ns)->type == BT_DERIVED)
+ 	gfc_set_default_type (sym, 0, implicit_ns);
++      gfc_current_locus = old_loc;
+     }
+ 
+   expr = gfc_get_expr ();
+diff --git a/gcc/fortran/resolve.c b/gcc/fortran/resolve.c
+index 4fa7cb5..33f0387 100644
+--- a/gcc/fortran/resolve.c
++++ b/gcc/fortran/resolve.c
+@@ -520,7 +520,7 @@ static void
+ find_arglists (gfc_symbol *sym)
+ {
+   if (sym->attr.if_source == IFSRC_UNKNOWN || sym->ns != gfc_current_ns
+-      || sym->attr.flavor == FL_DERIVED)
++      || gfc_fl_struct (sym->attr.flavor))
+     return;
+ 
+   resolve_formal_arglist (sym);
+@@ -942,9 +942,9 @@ resolve_common_vars (gfc_symbol *sym, bool named_common)
+ 		       "has an ultimate component that is "
+ 		       "allocatable", csym->name, &csym->declared_at);
+       if (gfc_has_default_initializer (csym->ts.u.derived))
+-	gfc_error_now ("Derived type variable '%s' in COMMON at %L "
+-		       "may not have default initializer", csym->name,
+-		       &csym->declared_at);
++        gfc_error_now ("Derived type variable '%s' in COMMON at %L "
++                       "may not have default initializer", csym->name,
++                       &csym->declared_at);
+ 
+       if (csym->attr.flavor == FL_UNKNOWN && !csym->attr.proc_pointer)
+ 	gfc_add_flavor (&csym->attr, FL_VARIABLE, csym->name, &csym->declared_at);
+@@ -1026,7 +1026,7 @@ resolve_contained_functions (gfc_namespace *ns)
+ 
+ 
+ static gfc_try resolve_fl_derived0 (gfc_symbol *sym);
+-
++static gfc_try resolve_fl_union (gfc_symbol *sym);
+ 
+ /* Resolve all of the elements of a structure constructor and make sure that
+    the types are correct. The 'init' flag indicates that the given
+@@ -1044,6 +1044,8 @@ resolve_structure_cons (gfc_expr *expr, int init)
+ 
+   if (expr->ts.type == BT_DERIVED)
+     resolve_fl_derived0 (expr->ts.u.derived);
++  else if (expr->ts.type == BT_UNION)
++    resolve_fl_union (expr->ts.u.derived);
+ 
+   cons = gfc_constructor_first (expr->value.constructor);
+ 
+@@ -1064,6 +1066,10 @@ resolve_structure_cons (gfc_expr *expr, int init)
+       && cons->expr && cons->expr->expr_type == EXPR_NULL)
+     return SUCCESS;
+ 
++  /* Union constructors only have one constructor. */
++  if (expr->ts.type == BT_UNION)
++    return SUCCESS;
++
+   /* A constructor may have references if it is the result of substituting a
+      parameter variable.  In this case we just pull out the component we
+      want.  */
+@@ -1486,7 +1492,7 @@ is_illegal_recursion (gfc_symbol* sym, gfc_namespace* context)
+   gfc_namespace* real_context;
+ 
+   if (sym->attr.flavor == FL_PROGRAM
+-      || sym->attr.flavor == FL_DERIVED)
++      || gfc_fl_struct (sym->attr.flavor))
+     return false;
+ 
+   gcc_assert (sym->attr.flavor == FL_PROCEDURE);
+@@ -2455,7 +2461,7 @@ resolve_generic_f (gfc_expr *expr)
+ generic:
+       if (!intr)
+ 	for (intr = sym->generic; intr; intr = intr->next)
+-	  if (intr->sym->attr.flavor == FL_DERIVED)
++	  if (gfc_fl_struct (intr->sym->attr.flavor))
+ 	    break;
+ 
+       if (sym->ns->parent == NULL)
+@@ -6067,7 +6073,7 @@ get_declared_from_expr (gfc_ref **class_ref, gfc_ref **new_ref,
+ 	continue;
+ 
+       if ((ref->u.c.component->ts.type == BT_CLASS
+-	     || (check_types && ref->u.c.component->ts.type == BT_DERIVED))
++	     || (check_types && gfc_bt_struct (ref->u.c.component->ts.type)))
+ 	  && ref->u.c.component->attr.flavor != FL_PROCEDURE)
+ 	{
+ 	  declared = ref->u.c.component->ts.u.derived;
+@@ -6328,7 +6334,7 @@ resolve_typebound_function (gfc_expr* e)
+ 	 is present.  */
+       ts = expr->ts;
+       declared = ts.u.derived;
+-      c = gfc_find_component (declared, "_vptr", true, true);
++      c = gfc_find_component (declared, "_vptr", true, true, NULL);
+       if (c->ts.u.derived == NULL)
+ 	c->ts.u.derived = gfc_find_derived_vtab (declared);
+ 
+@@ -6372,14 +6378,14 @@ resolve_typebound_function (gfc_expr* e)
+   declared = get_declared_from_expr (&class_ref, &new_ref, e, true);
+ 
+   /* Weed out cases of the ultimate component being a derived type.  */
+-  if ((class_ref && class_ref->u.c.component->ts.type == BT_DERIVED)
++  if ((class_ref && gfc_bt_struct (class_ref->u.c.component->ts.type))
+ 	 || (!class_ref && st->n.sym->ts.type != BT_CLASS))
+     {
+       gfc_free_ref_list (new_ref);
+       return resolve_compcall (e, NULL);
+     }
+ 
+-  c = gfc_find_component (declared, "_data", true, true);
++  c = gfc_find_component (declared, "_data", true, true, NULL);
+   declared = c->ts.u.derived;
+ 
+   /* Treat the call as if it is a typebound procedure, in order to roll
+@@ -6456,7 +6462,7 @@ resolve_typebound_subroutine (gfc_code *code)
+ 	 that any delays in resolution are corrected and that the vtab
+ 	 is present.  */
+       declared = expr->ts.u.derived;
+-      c = gfc_find_component (declared, "_vptr", true, true);
++      c = gfc_find_component (declared, "_vptr", true, true, NULL);
+       if (c->ts.u.derived == NULL)
+ 	c->ts.u.derived = gfc_find_derived_vtab (declared);
+ 
+@@ -6501,7 +6507,7 @@ resolve_typebound_subroutine (gfc_code *code)
+   get_declared_from_expr (&class_ref, &new_ref, code->expr1, true);
+ 
+   /* Weed out cases of the ultimate component being a derived type.  */
+-  if ((class_ref && class_ref->u.c.component->ts.type == BT_DERIVED)
++  if ((class_ref && gfc_bt_struct (class_ref->u.c.component->ts.type))
+ 	 || (!class_ref && st->n.sym->ts.type != BT_CLASS))
+     {
+       gfc_free_ref_list (new_ref);
+@@ -7446,7 +7452,7 @@ resolve_allocate_expr (gfc_expr *e, gfc_code *code)
+ 	 using _copy and trans_call. It is convenient to exploit that
+ 	 when the allocated type is different from the declared type but
+ 	 no SOURCE exists by setting expr3.  */
+-      code->expr3 = gfc_default_initializer (&code->ext.alloc.ts);
++      code->expr3 = gfc_default_initializer (&code->ext.alloc.ts, false);
+     }
+   else if (!code->expr3)
+     {
+@@ -7454,7 +7460,7 @@ resolve_allocate_expr (gfc_expr *e, gfc_code *code)
+       gfc_typespec ts;
+       gfc_expr *init_e;
+ 
+-      if (code->ext.alloc.ts.type == BT_DERIVED)
++      if (gfc_bt_struct (code->ext.alloc.ts.type))
+ 	ts = code->ext.alloc.ts;
+       else
+ 	ts = e->ts;
+@@ -7462,7 +7468,8 @@ resolve_allocate_expr (gfc_expr *e, gfc_code *code)
+       if (ts.type == BT_CLASS)
+ 	ts = ts.u.derived->components->ts;
+ 
+-      if (ts.type == BT_DERIVED && (init_e = gfc_default_initializer (&ts)))
++      if (gfc_bt_struct (ts.type) && (init_e = gfc_default_initializer (&ts,
++                                                                        false)))
+ 	{
+ 	  gfc_code *init_st = gfc_get_code ();
+ 	  init_st->loc = code->loc;
+@@ -7476,7 +7483,7 @@ resolve_allocate_expr (gfc_expr *e, gfc_code *code)
+   else if (code->expr3->mold && code->expr3->ts.type == BT_DERIVED)
+     {
+       /* Default initialization via MOLD (non-polymorphic).  */
+-      gfc_expr *rhs = gfc_default_initializer (&code->expr3->ts);
++      gfc_expr *rhs = gfc_default_initializer (&code->expr3->ts, false);
+       gfc_resolve_expr (rhs);
+       gfc_free_expr (code->expr3);
+       code->expr3 = rhs;
+@@ -7578,7 +7585,7 @@ check_symbols:
+ 	  sym = a->expr->symtree->n.sym;
+ 
+ 	  /* TODO - check derived type components.  */
+-	  if (sym->ts.type == BT_DERIVED || sym->ts.type == BT_CLASS)
++	  if (gfc_bt_struct (sym->ts.type) || sym->ts.type == BT_CLASS)
+ 	    continue;
+ 
+ 	  if ((ar->start[i] != NULL
+@@ -9935,7 +9942,7 @@ nonscalar_typebound_assign (gfc_symbol *derived, int depth)
+ 
+   for (c= derived->components; c; c = c->next)
+     {
+-      if ((c->ts.type != BT_DERIVED
++      if ((!gfc_bt_struct (c->ts.type)
+ 	    || c->attr.pointer
+ 	    || c->attr.allocatable
+ 	    || c->attr.proc_pointer_comp
+@@ -10009,9 +10016,172 @@ static int component_assignment_level = 0;
+ static gfc_code *tmp_head = NULL, *tmp_tail = NULL;
+ 
+ static void
++generate_derived_component_assignments (gfc_code **code, gfc_namespace *ns,
++    gfc_code **this_code, gfc_code **head, gfc_code **tail, gfc_expr **t1,
++    gfc_symbol *d1, gfc_symbol *d2)
++{
++  gfc_component *comp1, *comp2, *map1, *map2;
++
++  comp1 = d1->components;
++  comp2 = d2->components;
++
++  for (; comp1; comp1 = comp1->next, comp2 = comp2->next)
++  {
++    bool inout = false;
++
++    /* For unions, just recurse into the maps. */
++    if (comp1->ts.type == BT_UNION)
++    {
++      map1 = comp1->ts.u.derived->components;
++      map2 = comp2->ts.u.derived->components;
++      for (; map1; map1 = map1->next, map2 = map2->next)
++      {
++        generate_derived_component_assignments (code, ns,
++            this_code, head, tail, t1, map1->ts.u.derived, map2->ts.u.derived);
++      }
++      continue;
++    }
++
++    /* The intrinsic assignment does the right thing for pointers
++       of all kinds and allocatable components.  */
++    if (comp1->ts.type != BT_DERIVED
++        || comp1->attr.pointer
++        || comp1->attr.allocatable
++        || comp1->attr.proc_pointer_comp
++        || comp1->attr.class_pointer
++        || comp1->attr.proc_pointer)
++      continue;
++
++    /* Make an assigment for this component.  */
++    *this_code = build_assignment (EXEC_ASSIGN,
++                                  (*code)->expr1, (*code)->expr2,
++                                  comp1, comp2, (*code)->loc);
++
++    /* Convert the assignment if there is a defined assignment for
++       this type.  Otherwise, using the call from resolve_code,
++       recurse into its components.  */
++    resolve_code (*this_code, ns);
++
++    if ((*this_code)->op == EXEC_ASSIGN_CALL)
++      {
++        gfc_formal_arglist *dummy_args;
++        gfc_symbol *rsym;
++        /* Check that there is a typebound defined assignment.  If not,
++           then this must be a module defined assignment.  We cannot
++           use the defined_assign_comp attribute here because it must
++           be this derived type that has the defined assignment and not
++           a parent type.  */
++        if (!(comp1->ts.u.derived->f2k_derived
++              && comp1->ts.u.derived->f2k_derived
++                                      ->tb_op[INTRINSIC_ASSIGN]))
++          {
++            gfc_free_statements (*this_code);
++            *this_code = NULL;
++            continue;
++          }
++
++        /* If the first argument of the subroutine has intent INOUT
++           a temporary must be generated and used instead.  */
++        rsym = (*this_code)->resolved_sym;
++        dummy_args = gfc_sym_get_dummy_args (rsym);
++        if (dummy_args
++            && dummy_args->sym->attr.intent == INTENT_INOUT)
++          {
++            gfc_code *temp_code;
++            inout = true;
++
++            /* Build the temporary required for the assignment and put
++               it at the head of the generated code.  */
++            if (!*t1)
++              {
++                *t1 = get_temp_from_expr ((*code)->expr1, ns);
++                temp_code = build_assignment (EXEC_ASSIGN,
++                                              *t1, (*code)->expr1,
++                              NULL, NULL, (*code)->loc);
++
++                /* For allocatable LHS, check whether it is allocated.  Note
++                   that allocatable components with defined assignment are
++                   not yet support.  See PR 57696.  */
++                if ((*code)->expr1->symtree->n.sym->attr.allocatable)
++                  {
++                    gfc_code *block;
++                    gfc_expr *e =
++                      gfc_lval_expr_from_sym ((*code)->expr1->symtree->n.sym);
++                    block = gfc_get_code ();
++                    block->op = EXEC_IF;
++                    block->block = gfc_get_code ();
++                    block->block->op = EXEC_IF;
++                    block->block->expr1
++                        = gfc_build_intrinsic_call (ns,
++                                  GFC_ISYM_ALLOCATED, "allocated",
++                                  (*code)->loc, 1, e);
++                    block->block->next = temp_code;
++                    temp_code = block;
++                  }
++                add_code_to_chain (&temp_code, &tmp_head, &tmp_tail);
++              }
++
++            /* Replace the first actual arg with the component of the
++               temporary.  */
++            gfc_free_expr ((*this_code)->ext.actual->expr);
++            (*this_code)->ext.actual->expr = gfc_copy_expr (*t1);
++            add_comp_ref ((*this_code)->ext.actual->expr, comp1);
++
++            /* If the LHS variable is allocatable and wasn't allocated and
++               the temporary is allocatable, pointer assign the address of
++               the freshly allocated LHS to the temporary.  */
++            if ((*code)->expr1->symtree->n.sym->attr.allocatable
++                && gfc_expr_attr ((*code)->expr1).allocatable)
++              {
++                gfc_code *block;
++                gfc_expr *cond;
++
++                cond = gfc_get_expr ();
++                cond->ts.type = BT_LOGICAL;
++                cond->ts.kind = gfc_default_logical_kind;
++                cond->expr_type = EXPR_OP;
++                cond->where = (*code)->loc;
++                cond->value.op.op = INTRINSIC_NOT;
++                cond->value.op.op1 = gfc_build_intrinsic_call (ns,
++                                        GFC_ISYM_ALLOCATED, "allocated",
++                                        (*code)->loc, 1, gfc_copy_expr (*t1));
++                block = gfc_get_code ();
++                block->op = EXEC_IF;
++                block->block = gfc_get_code ();
++                block->block->op = EXEC_IF;
++                block->block->expr1 = cond;
++                block->block->next = build_assignment (EXEC_POINTER_ASSIGN,
++                                      *t1, (*code)->expr1,
++                                      NULL, NULL, (*code)->loc);
++                add_code_to_chain (&block, head, tail);
++              }
++          }
++      }
++    else if ((*this_code)->op == EXEC_ASSIGN && !(*this_code)->next)
++      {
++        /* Don't add intrinsic assignments since they are already
++           effected by the intrinsic assignment of the structure.  */
++        gfc_free_statements (*this_code);
++        (*this_code) = NULL;
++        continue;
++      }
++
++    add_code_to_chain (this_code, head, tail);
++
++    if (*t1 && inout)
++      {
++        /* Transfer the value to the final result.  */
++        *this_code = build_assignment (EXEC_ASSIGN,
++                                      (*code)->expr1, *t1,
++                                      comp1, comp2, (*code)->loc);
++        add_code_to_chain (this_code, head, tail);
++      }
++  }
++}
++
++static void
+ generate_component_assignments (gfc_code **code, gfc_namespace *ns)
+ {
+-  gfc_component *comp1, *comp2;
+   gfc_code *this_code = NULL, *head = NULL, *tail = NULL;
+   gfc_expr *t1;
+   int error_count, depth;
+@@ -10065,149 +10235,11 @@ generate_component_assignments (gfc_code **code, gfc_namespace *ns)
+       add_code_to_chain (&this_code, &head, &tail);
+     }
+ 
+-  comp1 = (*code)->expr1->ts.u.derived->components;
+-  comp2 = (*code)->expr2->ts.u.derived->components;
+-
+   t1 = NULL;
+-  for (; comp1; comp1 = comp1->next, comp2 = comp2->next)
+-    {
+-      bool inout = false;
+-
+-      /* The intrinsic assignment does the right thing for pointers
+-	 of all kinds and allocatable components.  */
+-      if (comp1->ts.type != BT_DERIVED
+-	  || comp1->attr.pointer
+-	  || comp1->attr.allocatable
+-	  || comp1->attr.proc_pointer_comp
+-	  || comp1->attr.class_pointer
+-	  || comp1->attr.proc_pointer)
+-	continue;
+-
+-      /* Make an assigment for this component.  */
+-      this_code = build_assignment (EXEC_ASSIGN,
+-				    (*code)->expr1, (*code)->expr2,
+-				    comp1, comp2, (*code)->loc);
+-
+-      /* Convert the assignment if there is a defined assignment for
+-	 this type.  Otherwise, using the call from resolve_code,
+-	 recurse into its components.  */
+-      resolve_code (this_code, ns);
+-
+-      if (this_code->op == EXEC_ASSIGN_CALL)
+-	{
+-	  gfc_formal_arglist *dummy_args;
+-	  gfc_symbol *rsym;
+-	  /* Check that there is a typebound defined assignment.  If not,
+-	     then this must be a module defined assignment.  We cannot
+-	     use the defined_assign_comp attribute here because it must
+-	     be this derived type that has the defined assignment and not
+-	     a parent type.  */
+-	  if (!(comp1->ts.u.derived->f2k_derived
+-		&& comp1->ts.u.derived->f2k_derived
+-					->tb_op[INTRINSIC_ASSIGN]))
+-	    {
+-	      gfc_free_statements (this_code);
+-	      this_code = NULL;
+-	      continue;
+-	    }
+-
+-	  /* If the first argument of the subroutine has intent INOUT
+-	     a temporary must be generated and used instead.  */
+-	  rsym = this_code->resolved_sym;
+-	  dummy_args = gfc_sym_get_dummy_args (rsym);
+-	  if (dummy_args
+-	      && dummy_args->sym->attr.intent == INTENT_INOUT)
+-	    {
+-	      gfc_code *temp_code;
+-	      inout = true;
+-
+-	      /* Build the temporary required for the assignment and put
+-		 it at the head of the generated code.  */
+-	      if (!t1)
+-		{
+-		  t1 = get_temp_from_expr ((*code)->expr1, ns);
+-		  temp_code = build_assignment (EXEC_ASSIGN,
+-						t1, (*code)->expr1,
+-				NULL, NULL, (*code)->loc);
+-
+-		  /* For allocatable LHS, check whether it is allocated.  Note
+-		     that allocatable components with defined assignment are
+-		     not yet support.  See PR 57696.  */
+-		  if ((*code)->expr1->symtree->n.sym->attr.allocatable)
+-		    {
+-		      gfc_code *block;
+-		      gfc_expr *e =
+-			gfc_lval_expr_from_sym ((*code)->expr1->symtree->n.sym);
+-		      block = gfc_get_code ();
+-		      block->op = EXEC_IF;
+-		      block->block = gfc_get_code ();
+-		      block->block->op = EXEC_IF;
+-		      block->block->expr1
+-			  = gfc_build_intrinsic_call (ns,
+-				    GFC_ISYM_ALLOCATED, "allocated",
+-				    (*code)->loc, 1, e);
+-		      block->block->next = temp_code;
+-		      temp_code = block;
+-		    }
+-		  add_code_to_chain (&temp_code, &tmp_head, &tmp_tail);
+-		}
+ 
+-	      /* Replace the first actual arg with the component of the
+-		 temporary.  */
+-	      gfc_free_expr (this_code->ext.actual->expr);
+-	      this_code->ext.actual->expr = gfc_copy_expr (t1);
+-	      add_comp_ref (this_code->ext.actual->expr, comp1);
+-
+-	      /* If the LHS variable is allocatable and wasn't allocated and
+-                 the temporary is allocatable, pointer assign the address of
+-                 the freshly allocated LHS to the temporary.  */
+-	      if ((*code)->expr1->symtree->n.sym->attr.allocatable
+-		  && gfc_expr_attr ((*code)->expr1).allocatable)
+-		{
+-		  gfc_code *block;
+-		  gfc_expr *cond;
+-
+-		  cond = gfc_get_expr ();
+-		  cond->ts.type = BT_LOGICAL;
+-		  cond->ts.kind = gfc_default_logical_kind;
+-		  cond->expr_type = EXPR_OP;
+-		  cond->where = (*code)->loc;
+-		  cond->value.op.op = INTRINSIC_NOT;
+-		  cond->value.op.op1 = gfc_build_intrinsic_call (ns,
+-					  GFC_ISYM_ALLOCATED, "allocated",
+-					  (*code)->loc, 1, gfc_copy_expr (t1));
+-		  block = gfc_get_code ();
+-		  block->op = EXEC_IF;
+-		  block->block = gfc_get_code ();
+-		  block->block->op = EXEC_IF;
+-		  block->block->expr1 = cond;
+-		  block->block->next = build_assignment (EXEC_POINTER_ASSIGN,
+-					t1, (*code)->expr1,
+-					NULL, NULL, (*code)->loc);
+-		  add_code_to_chain (&block, &head, &tail);
+-		}
+-	    }
+-	}
+-      else if (this_code->op == EXEC_ASSIGN && !this_code->next)
+-	{
+-	  /* Don't add intrinsic assignments since they are already
+-	     effected by the intrinsic assignment of the structure.  */
+-	  gfc_free_statements (this_code);
+-	  this_code = NULL;
+-	  continue;
+-	}
+-
+-      add_code_to_chain (&this_code, &head, &tail);
+-
+-      if (t1 && inout)
+-	{
+-	  /* Transfer the value to the final result.  */
+-	  this_code = build_assignment (EXEC_ASSIGN,
+-					(*code)->expr1, t1,
+-					comp1, comp2, (*code)->loc);
+-	  add_code_to_chain (&this_code, &head, &tail);
+-	}
+-    }
++  generate_derived_component_assignments (code, ns,
++      &this_code, &head, &tail, &t1,
++      (*code)->expr1->ts.u.derived, (*code)->expr2->ts.u.derived);
+ 
+   /* Put the temporary assignments at the top of the generated code.  */
+   if (tmp_head && component_assignment_level == 1)
+@@ -10779,7 +10811,7 @@ resolve_bind_c_comms (gfc_symtree *comm_block_tree)
+ static void
+ resolve_bind_c_derived_types (gfc_symbol *derived_sym)
+ {
+-  if (derived_sym != NULL && derived_sym->attr.flavor == FL_DERIVED
++  if (derived_sym != NULL && gfc_fl_struct (derived_sym->attr.flavor)
+       && derived_sym->attr.is_bind_c == 1)
+     verify_bind_c_derived_type (derived_sym);
+ 
+@@ -10796,7 +10828,7 @@ gfc_verify_binding_labels (gfc_symbol *sym)
+   int has_error = 0;
+ 
+   if (sym != NULL && sym->attr.is_bind_c && sym->attr.is_iso_c == 0
+-      && sym->attr.flavor != FL_DERIVED && sym->binding_label)
++      && !gfc_fl_struct (sym->attr.flavor) && sym->binding_label)
+     {
+       gfc_gsymbol *bind_c_sym;
+ 
+@@ -11031,6 +11063,34 @@ build_init_assign (gfc_symbol *sym, gfc_expr *init)
+   init_st->expr2 = init;
+ }
+ 
++/* Whether or not we can create an initializer for the given symbol.  */
++
++static bool
++can_create_init (gfc_symbol *sym)
++{
++  symbol_attribute *a;
++  if (!sym)
++    return false;
++  a = &sym->attr;
++
++  /* These symbols should never have a default initialization.  */
++  return !(
++       a->allocatable
++    || a->external
++    || a->pointer
++    || a->in_equivalence
++    || a->in_common
++    || a->data
++    || sym->module
++    || a->cray_pointee
++    || a->cray_pointer
++    || sym->assoc
++    || (!a->referenced && !a->result)
++    || (a->dummy && a->intent != INTENT_OUT)
++    || (a->function && sym != sym->result)
++  );
++} 
++
+ /* Assign the default initializer to a derived type variable or result.  */
+ 
+ static void
+@@ -11042,7 +11102,7 @@ apply_default_init (gfc_symbol *sym)
+     return;
+ 
+   if (sym->ts.type == BT_DERIVED && sym->ts.u.derived)
+-    init = gfc_default_initializer (&sym->ts);
++    init = gfc_default_initializer (&sym->ts, can_create_init (sym));
+ 
+   if (init == NULL && sym->ts.type != BT_CLASS)
+     return;
+@@ -11364,7 +11424,7 @@ resolve_fl_variable_derived (gfc_symbol *sym, int no_init_flag)
+       gfc_find_symbol (sym->ts.u.derived->name, sym->ns, 0, &s);
+       if (s && s->attr.generic)
+ 	s = gfc_find_dt_in_generic (s);
+-      if (s && s->attr.flavor != FL_DERIVED)
++      if (s && !gfc_fl_struct (s->attr.flavor))
+ 	{
+ 	  gfc_error ("The type '%s' cannot be host associated at %L "
+ 		     "because it is blocked by an incompatible object "
+@@ -11398,7 +11458,7 @@ resolve_fl_variable_derived (gfc_symbol *sym, int no_init_flag)
+   if (!(sym->value || sym->attr.pointer || sym->attr.allocatable)
+       && (!no_init_flag || sym->attr.intent == INTENT_OUT))
+     {
+-      sym->value = gfc_default_initializer (&sym->ts);
++      sym->value = gfc_default_initializer (&sym->ts, can_create_init (sym));
+     }
+ 
+   return SUCCESS;
+@@ -12539,7 +12599,8 @@ resolve_typebound_procedure (gfc_symtree* stree)
+       }
+ 
+   /* Try to find a name collision with an inherited component.  */
+-  if (super_type && gfc_find_component (super_type, stree->name, true, true))
++  if (super_type && gfc_find_component (super_type, stree->name, true, true,
++                                        NULL))
+     {
+       gfc_error ("Procedure '%s' at %L has the same name as an inherited"
+ 		 " component of '%s'",
+@@ -12687,7 +12748,7 @@ check_defined_assignments (gfc_symbol *derived)
+ 
+   for (c = derived->components; c; c = c->next)
+     {
+-      if (c->ts.type != BT_DERIVED
++      if (!gfc_bt_struct (c->ts.type)
+ 	  || c->attr.pointer
+ 	  || c->attr.allocatable
+ 	  || c->attr.proc_pointer_comp
+@@ -12712,402 +12773,459 @@ check_defined_assignments (gfc_symbol *derived)
+     }
+ }
+ 
+-
+-/* Resolve the components of a derived type. This does not have to wait until
+-   resolution stage, but can be done as soon as the dt declaration has been
+-   parsed.  */
++/* Resolve a component (for resolve_fl_derived0). */
+ 
+ static gfc_try
+-resolve_fl_derived0 (gfc_symbol *sym)
++resolve_component (gfc_component *c, void *data)
+ {
+-  gfc_symbol* super_type;
+-  gfc_component *c;
++  gfc_symbol *sym = (gfc_symbol *)data;
++  gfc_symbol *super_type = gfc_get_derived_super_type (sym);
+ 
+-  if (sym->attr.unlimited_polymorphic)
++  if (c->attr.artificial)
+     return SUCCESS;
+ 
+-  super_type = gfc_get_derived_super_type (sym);
++  /* See PRs 51550, 47545, 48654, 49050, 51075 - and 45170.  */
++  if (c->ts.type == BT_CHARACTER && c->ts.deferred && !c->attr.function)
++    {
++      gfc_error ("Deferred-length character component '%s' at %L is not "
++                 "yet supported", c->name, &c->loc);
++      return FAILURE;
++    }
+ 
+-  /* F2008, C432. */
+-  if (super_type && sym->attr.coarray_comp && !super_type->attr.coarray_comp)
++  /* F2008, C442.  */
++  if ((!sym->attr.is_class || c != sym->components)
++      && c->attr.codimension
++      && (!c->attr.allocatable || (c->as && c->as->type != AS_DEFERRED)))
+     {
+-      gfc_error ("As extending type '%s' at %L has a coarray component, "
+-		 "parent type '%s' shall also have one", sym->name,
+-		 &sym->declared_at, super_type->name);
++      gfc_error ("Coarray component '%s' at %L must be allocatable with "
++                 "deferred shape", c->name, &c->loc);
+       return FAILURE;
+     }
+ 
+-  /* Ensure the extended type gets resolved before we do.  */
+-  if (super_type && resolve_fl_derived0 (super_type) == FAILURE)
+-    return FAILURE;
++  /* F2008, C443.  */
++  if (c->attr.codimension && c->ts.type == BT_DERIVED
++      && c->ts.u.derived->ts.is_iso_c)
++    {
++      gfc_error ("Component '%s' at %L of TYPE(C_PTR) or TYPE(C_FUNPTR) "
++                 "shall not be a coarray", c->name, &c->loc);
++      return FAILURE;
++    }
+ 
+-  /* An ABSTRACT type must be extensible.  */
+-  if (sym->attr.abstract && !gfc_type_is_extensible (sym))
++  /* F2008, C444.  */
++  if (c->ts.type == BT_DERIVED && c->ts.u.derived->attr.coarray_comp
++      && (c->attr.codimension || c->attr.pointer || c->attr.dimension
++          || c->attr.allocatable))
+     {
+-      gfc_error ("Non-extensible derived-type '%s' at %L must not be ABSTRACT",
+-		 sym->name, &sym->declared_at);
++      gfc_error ("Component '%s' at %L with coarray component "
++                 "shall be a nonpointer, nonallocatable scalar",
++                 c->name, &c->loc);
+       return FAILURE;
+     }
+ 
+-  c = (sym->attr.is_class) ? sym->components->ts.u.derived->components
+-			   : sym->components;
++  /* F2008, C448.  */
++  if (c->attr.contiguous && (!c->attr.dimension || !c->attr.pointer))
++    {
++      gfc_error ("Component '%s' at %L has the CONTIGUOUS attribute but "
++                 "is not an array pointer", c->name, &c->loc);
++      return FAILURE;
++    }
+ 
+-  for ( ; c != NULL; c = c->next)
++  if (c->attr.proc_pointer && c->ts.interface)
+     {
+-      if (c->attr.artificial)
+-	continue;
++      gfc_symbol *ifc = c->ts.interface;
+ 
+-      /* See PRs 51550, 47545, 48654, 49050, 51075 - and 45170.  */
+-      if (c->ts.type == BT_CHARACTER && c->ts.deferred && !c->attr.function)
+-	{
+-	  gfc_error ("Deferred-length character component '%s' at %L is not "
+-		     "yet supported", c->name, &c->loc);
+-	  return FAILURE;
+-	}
++      if (!sym->attr.vtype
++          && check_proc_interface (ifc, &c->loc) == FAILURE)
++        {
++          c->tb->error = 1;
++          return FAILURE;
++        }
+ 
+-      /* F2008, C442.  */
+-      if ((!sym->attr.is_class || c != sym->components)
+-	  && c->attr.codimension
+-	  && (!c->attr.allocatable || (c->as && c->as->type != AS_DEFERRED)))
+-	{
+-	  gfc_error ("Coarray component '%s' at %L must be allocatable with "
+-		     "deferred shape", c->name, &c->loc);
+-	  return FAILURE;
+-	}
++      if (ifc->attr.if_source || ifc->attr.intrinsic)
++        {
++          /* Resolve interface and copy attributes.  */
++          if (ifc->formal && !ifc->formal_ns)
++            resolve_symbol (ifc);
++          if (ifc->attr.intrinsic)
++            gfc_resolve_intrinsic (ifc, &ifc->declared_at);
+ 
+-      /* F2008, C443.  */
+-      if (c->attr.codimension && c->ts.type == BT_DERIVED
+-	  && c->ts.u.derived->ts.is_iso_c)
+-	{
+-	  gfc_error ("Component '%s' at %L of TYPE(C_PTR) or TYPE(C_FUNPTR) "
+-		     "shall not be a coarray", c->name, &c->loc);
+-	  return FAILURE;
+-	}
++          if (ifc->result)
++            {
++              c->ts = ifc->result->ts;
++              c->attr.allocatable = ifc->result->attr.allocatable;
++              c->attr.pointer = ifc->result->attr.pointer;
++              c->attr.dimension = ifc->result->attr.dimension;
++              c->as = gfc_copy_array_spec (ifc->result->as);
++              c->attr.class_ok = ifc->result->attr.class_ok;
++            }
++          else
++            {
++              c->ts = ifc->ts;
++              c->attr.allocatable = ifc->attr.allocatable;
++              c->attr.pointer = ifc->attr.pointer;
++              c->attr.dimension = ifc->attr.dimension;
++              c->as = gfc_copy_array_spec (ifc->as);
++              c->attr.class_ok = ifc->attr.class_ok;
++            }
++          c->ts.interface = ifc;
++          c->attr.function = ifc->attr.function;
++          c->attr.subroutine = ifc->attr.subroutine;
++
++          c->attr.pure = ifc->attr.pure;
++          c->attr.elemental = ifc->attr.elemental;
++          c->attr.recursive = ifc->attr.recursive;
++          c->attr.always_explicit = ifc->attr.always_explicit;
++          c->attr.ext_attr |= ifc->attr.ext_attr;
++          /* Copy char length.  */
++          if (ifc->ts.type == BT_CHARACTER && ifc->ts.u.cl)
++            {
++              gfc_charlen *cl = gfc_new_charlen (sym->ns, ifc->ts.u.cl);
++              if (cl->length && !cl->resolved
++                  && gfc_resolve_expr (cl->length) == FAILURE)
++                {
++                  c->tb->error = 1;
++                  return FAILURE;
++                }
++              c->ts.u.cl = cl;
++            }
++        }
++    }
++  else if (c->attr.proc_pointer && c->ts.type == BT_UNKNOWN)
++    {
++      /* Since PPCs are not implicitly typed, a PPC without an explicit
++         interface must be a subroutine.  */
++      gfc_add_subroutine (&c->attr, c->name, &c->loc);
++    }
+ 
+-      /* F2008, C444.  */
+-      if (c->ts.type == BT_DERIVED && c->ts.u.derived->attr.coarray_comp
+-	  && (c->attr.codimension || c->attr.pointer || c->attr.dimension
+-	      || c->attr.allocatable))
+-	{
+-	  gfc_error ("Component '%s' at %L with coarray component "
+-		     "shall be a nonpointer, nonallocatable scalar",
+-		     c->name, &c->loc);
+-	  return FAILURE;
+-	}
++  /* Procedure pointer components: Check PASS arg.  */
++  if (c->attr.proc_pointer && !c->tb->nopass && c->tb->pass_arg_num == 0
++      && !sym->attr.vtype)
++    {
++      gfc_symbol* me_arg;
+ 
+-      /* F2008, C448.  */
+-      if (c->attr.contiguous && (!c->attr.dimension || !c->attr.pointer))
+-	{
+-	  gfc_error ("Component '%s' at %L has the CONTIGUOUS attribute but "
+-		     "is not an array pointer", c->name, &c->loc);
+-	  return FAILURE;
+-	}
++      if (c->tb->pass_arg)
++        {
++          gfc_formal_arglist* i;
+ 
+-      if (c->attr.proc_pointer && c->ts.interface)
+-	{
+-	  gfc_symbol *ifc = c->ts.interface;
++          /* If an explicit passing argument name is given, walk the arg-list
++            and look for it.  */
+ 
+-	  if (!sym->attr.vtype
+-	      && check_proc_interface (ifc, &c->loc) == FAILURE)
+-	    return FAILURE;
++          me_arg = NULL;
++          c->tb->pass_arg_num = 1;
++          for (i = c->ts.interface->formal; i; i = i->next)
++            {
++              if (!strcmp (i->sym->name, c->tb->pass_arg))
++                {
++                  me_arg = i->sym;
++                  break;
++                }
++              c->tb->pass_arg_num++;
++            }
+ 
+-	  if (ifc->attr.if_source || ifc->attr.intrinsic)
+-	    {
+-	      /* Resolve interface and copy attributes.  */
+-	      if (ifc->formal && !ifc->formal_ns)
+-		resolve_symbol (ifc);
+-	      if (ifc->attr.intrinsic)
+-		gfc_resolve_intrinsic (ifc, &ifc->declared_at);
++          if (!me_arg)
++            {
++              gfc_error ("Procedure pointer component '%s' with PASS(%s) "
++                         "at %L has no argument '%s'", c->name,
++                         c->tb->pass_arg, &c->loc, c->tb->pass_arg);
++              c->tb->error = 1;
++              return FAILURE;
++            }
++        }
++      else
++        {
++          /* Otherwise, take the first one; there should in fact be at least
++            one.  */
++          c->tb->pass_arg_num = 1;
++          if (!c->ts.interface->formal)
++            {
++              gfc_error ("Procedure pointer component '%s' with PASS at %L "
++                         "must have at least one argument",
++                         c->name, &c->loc);
++              c->tb->error = 1;
++              return FAILURE;
++            }
++          me_arg = c->ts.interface->formal->sym;
++        }
+ 
+-	      if (ifc->result)
+-		{
+-		  c->ts = ifc->result->ts;
+-		  c->attr.allocatable = ifc->result->attr.allocatable;
+-		  c->attr.pointer = ifc->result->attr.pointer;
+-		  c->attr.dimension = ifc->result->attr.dimension;
+-		  c->as = gfc_copy_array_spec (ifc->result->as);
+-		  c->attr.class_ok = ifc->result->attr.class_ok;
+-		}
+-	      else
+-		{
+-		  c->ts = ifc->ts;
+-		  c->attr.allocatable = ifc->attr.allocatable;
+-		  c->attr.pointer = ifc->attr.pointer;
+-		  c->attr.dimension = ifc->attr.dimension;
+-		  c->as = gfc_copy_array_spec (ifc->as);
+-		  c->attr.class_ok = ifc->attr.class_ok;
+-		}
+-	      c->ts.interface = ifc;
+-	      c->attr.function = ifc->attr.function;
+-	      c->attr.subroutine = ifc->attr.subroutine;
+-
+-	      c->attr.pure = ifc->attr.pure;
+-	      c->attr.elemental = ifc->attr.elemental;
+-	      c->attr.recursive = ifc->attr.recursive;
+-	      c->attr.always_explicit = ifc->attr.always_explicit;
+-	      c->attr.ext_attr |= ifc->attr.ext_attr;
+-	      /* Copy char length.  */
+-	      if (ifc->ts.type == BT_CHARACTER && ifc->ts.u.cl)
+-		{
+-		  gfc_charlen *cl = gfc_new_charlen (sym->ns, ifc->ts.u.cl);
+-		  if (cl->length && !cl->resolved
+-		      && gfc_resolve_expr (cl->length) == FAILURE)
+-		    return FAILURE;
+-		  c->ts.u.cl = cl;
+-		}
+-	    }
+-	}
+-      else if (c->attr.proc_pointer && c->ts.type == BT_UNKNOWN)
+-	{
+-	  /* Since PPCs are not implicitly typed, a PPC without an explicit
+-	     interface must be a subroutine.  */
+-	  gfc_add_subroutine (&c->attr, c->name, &c->loc);
+-	}
++      /* Now check that the argument-type matches.  */
++      gcc_assert (me_arg);
++      if ((me_arg->ts.type != BT_DERIVED && me_arg->ts.type != BT_CLASS)
++          || (me_arg->ts.type == BT_DERIVED && me_arg->ts.u.derived != sym)
++          || (me_arg->ts.type == BT_CLASS
++              && CLASS_DATA (me_arg)->ts.u.derived != sym))
++        {
++          gfc_error ("Argument '%s' of '%s' with PASS(%s) at %L must be of"
++                     " the derived type '%s'", me_arg->name, c->name,
++                     me_arg->name, &c->loc, sym->name);
++          c->tb->error = 1;
++          return FAILURE;
++        }
+ 
+-      /* Procedure pointer components: Check PASS arg.  */
+-      if (c->attr.proc_pointer && !c->tb->nopass && c->tb->pass_arg_num == 0
+-	  && !sym->attr.vtype)
+-	{
+-	  gfc_symbol* me_arg;
++      /* Check for C453.  */
++      if (me_arg->attr.dimension)
++        {
++          gfc_error ("Argument '%s' of '%s' with PASS(%s) at %L "
++                     "must be scalar", me_arg->name, c->name, me_arg->name,
++                     &c->loc);
++          c->tb->error = 1;
++          return FAILURE;
++        }
+ 
+-	  if (c->tb->pass_arg)
+-	    {
+-	      gfc_formal_arglist* i;
++      if (me_arg->attr.pointer)
++        {
++          gfc_error ("Argument '%s' of '%s' with PASS(%s) at %L "
++                     "may not have the POINTER attribute", me_arg->name,
++                     c->name, me_arg->name, &c->loc);
++          c->tb->error = 1;
++          return FAILURE;
++        }
+ 
+-	      /* If an explicit passing argument name is given, walk the arg-list
+-		and look for it.  */
++      if (me_arg->attr.allocatable)
++        {
++          gfc_error ("Argument '%s' of '%s' with PASS(%s) at %L "
++                     "may not be ALLOCATABLE", me_arg->name, c->name,
++                     me_arg->name, &c->loc);
++          c->tb->error = 1;
++          return FAILURE;
++        }
+ 
+-	      me_arg = NULL;
+-	      c->tb->pass_arg_num = 1;
+-	      for (i = c->ts.interface->formal; i; i = i->next)
+-		{
+-		  if (!strcmp (i->sym->name, c->tb->pass_arg))
+-		    {
+-		      me_arg = i->sym;
+-		      break;
+-		    }
+-		  c->tb->pass_arg_num++;
+-		}
++      if (gfc_type_is_extensible (sym) && me_arg->ts.type != BT_CLASS)
++        {
++          gfc_error ("Non-polymorphic passed-object dummy argument of '%s'"
++                     " at %L", c->name, &c->loc);
++          return FAILURE;
++        }
+ 
+-	      if (!me_arg)
+-		{
+-		  gfc_error ("Procedure pointer component '%s' with PASS(%s) "
+-			     "at %L has no argument '%s'", c->name,
+-			     c->tb->pass_arg, &c->loc, c->tb->pass_arg);
+-		  c->tb->error = 1;
+-		  return FAILURE;
+-		}
+-	    }
+-	  else
+-	    {
+-	      /* Otherwise, take the first one; there should in fact be at least
+-		one.  */
+-	      c->tb->pass_arg_num = 1;
+-	      if (!c->ts.interface->formal)
+-		{
+-		  gfc_error ("Procedure pointer component '%s' with PASS at %L "
+-			     "must have at least one argument",
+-			     c->name, &c->loc);
+-		  c->tb->error = 1;
+-		  return FAILURE;
+-		}
+-	      me_arg = c->ts.interface->formal->sym;
+-	    }
++    }
+ 
+-	  /* Now check that the argument-type matches.  */
+-	  gcc_assert (me_arg);
+-	  if ((me_arg->ts.type != BT_DERIVED && me_arg->ts.type != BT_CLASS)
+-	      || (me_arg->ts.type == BT_DERIVED && me_arg->ts.u.derived != sym)
+-	      || (me_arg->ts.type == BT_CLASS
+-		  && CLASS_DATA (me_arg)->ts.u.derived != sym))
+-	    {
+-	      gfc_error ("Argument '%s' of '%s' with PASS(%s) at %L must be of"
+-			 " the derived type '%s'", me_arg->name, c->name,
+-			 me_arg->name, &c->loc, sym->name);
+-	      c->tb->error = 1;
+-	      return FAILURE;
+-	    }
++  /* Check type-spec if this is not the parent-type component.  */
++  if (((sym->attr.is_class
++        && (!sym->components->ts.u.derived->attr.extension
++            || c != sym->components->ts.u.derived->components))
++       || (!sym->attr.is_class
++           && (!sym->attr.extension || c != sym->components)))
++      && !sym->attr.vtype
++      && resolve_typespec_used (&c->ts, &c->loc, c->name) == FAILURE)
++    return FAILURE;
+ 
+-	  /* Check for C453.  */
+-	  if (me_arg->attr.dimension)
+-	    {
+-	      gfc_error ("Argument '%s' of '%s' with PASS(%s) at %L "
+-			 "must be scalar", me_arg->name, c->name, me_arg->name,
+-			 &c->loc);
+-	      c->tb->error = 1;
+-	      return FAILURE;
+-	    }
++  /* If this type is an extension, set the accessibility of the parent
++     component.  */
++  if (super_type
++      && ((sym->attr.is_class
++           && c == sym->components->ts.u.derived->components)
++          || (!sym->attr.is_class && c == sym->components))
++      && strcmp (super_type->name, c->name) == 0)
++    c->attr.access = super_type->attr.access;
++
++  /* If this type is an extension, see if this component has the same name
++     as an inherited type-bound procedure.  */
++  if (super_type && !sym->attr.is_class
++      && gfc_find_typebound_proc (super_type, NULL, c->name, true, NULL))
++    {
++      gfc_error ("Component '%s' of '%s' at %L has the same name as an"
++                 " inherited type-bound procedure",
++                 c->name, sym->name, &c->loc);
++      return FAILURE;
++    }
+ 
+-	  if (me_arg->attr.pointer)
+-	    {
+-	      gfc_error ("Argument '%s' of '%s' with PASS(%s) at %L "
+-			 "may not have the POINTER attribute", me_arg->name,
+-			 c->name, me_arg->name, &c->loc);
+-	      c->tb->error = 1;
+-	      return FAILURE;
+-	    }
++  if (c->ts.type == BT_CHARACTER && !c->attr.proc_pointer
++        && !c->ts.deferred)
++    {
++     if (c->ts.u.cl->length == NULL
++         || (resolve_charlen (c->ts.u.cl) == FAILURE)
++         || !gfc_is_constant_expr (c->ts.u.cl->length))
++       {
++         gfc_error ("Character length of component '%s' needs to "
++                    "be a constant specification expression at %L",
++                    c->name,
++                    c->ts.u.cl->length ? &c->ts.u.cl->length->where : &c->loc);
++         return FAILURE;
++       }
++    }
+ 
+-	  if (me_arg->attr.allocatable)
+-	    {
+-	      gfc_error ("Argument '%s' of '%s' with PASS(%s) at %L "
+-			 "may not be ALLOCATABLE", me_arg->name, c->name,
+-			 me_arg->name, &c->loc);
+-	      c->tb->error = 1;
+-	      return FAILURE;
+-	    }
++  if (c->ts.type == BT_CHARACTER && c->ts.deferred
++      && !c->attr.pointer && !c->attr.allocatable)
++    {
++      gfc_error ("Character component '%s' of '%s' at %L with deferred "
++                 "length must be a POINTER or ALLOCATABLE",
++                 c->name, sym->name, &c->loc);
++      return FAILURE;
++    }
+ 
+-	  if (gfc_type_is_extensible (sym) && me_arg->ts.type != BT_CLASS)
+-	    gfc_error ("Non-polymorphic passed-object dummy argument of '%s'"
+-		       " at %L", c->name, &c->loc);
++  if (c->ts.type == BT_DERIVED
++      && sym->component_access != ACCESS_PRIVATE
++      && gfc_check_symbol_access (sym)
++      && !is_sym_host_assoc (c->ts.u.derived, sym->ns)
++      && !c->ts.u.derived->attr.use_assoc
++      && !gfc_check_symbol_access (c->ts.u.derived)
++      && gfc_notify_std (GFC_STD_F2003, "the component '%s' "
++                         "is a PRIVATE type and cannot be a component of "
++                         "'%s', which is PUBLIC at %L", c->name,
++                         sym->name, &sym->declared_at) == FAILURE)
++    return FAILURE;
+ 
+-	}
++  if ((sym->attr.sequence || sym->attr.is_bind_c) && c->ts.type == BT_CLASS)
++    {
++      gfc_error ("Polymorphic component %s at %L in SEQUENCE or BIND(C) "
++                 "type %s", c->name, &c->loc, sym->name);
++      return FAILURE;
++    }
+ 
+-      /* Check type-spec if this is not the parent-type component.  */
+-      if (((sym->attr.is_class
+-	    && (!sym->components->ts.u.derived->attr.extension
+-		|| c != sym->components->ts.u.derived->components))
+-	   || (!sym->attr.is_class
+-	       && (!sym->attr.extension || c != sym->components)))
+-	  && !sym->attr.vtype
+-	  && resolve_typespec_used (&c->ts, &c->loc, c->name) == FAILURE)
+-	return FAILURE;
++  if (sym->attr.sequence)
++    {
++      if (c->ts.type == BT_DERIVED && c->ts.u.derived->attr.sequence == 0)
++        {
++          gfc_error ("Component %s of SEQUENCE type declared at %L does "
++                     "not have the SEQUENCE attribute",
++                     c->ts.u.derived->name, &sym->declared_at);
++          return FAILURE;
++        }
++    }
+ 
+-      /* If this type is an extension, set the accessibility of the parent
+-	 component.  */
+-      if (super_type
+-	  && ((sym->attr.is_class
+-	       && c == sym->components->ts.u.derived->components)
+-	      || (!sym->attr.is_class && c == sym->components))
+-	  && strcmp (super_type->name, c->name) == 0)
+-	c->attr.access = super_type->attr.access;
+-
+-      /* If this type is an extension, see if this component has the same name
+-	 as an inherited type-bound procedure.  */
+-      if (super_type && !sym->attr.is_class
+-	  && gfc_find_typebound_proc (super_type, NULL, c->name, true, NULL))
+-	{
+-	  gfc_error ("Component '%s' of '%s' at %L has the same name as an"
+-		     " inherited type-bound procedure",
+-		     c->name, sym->name, &c->loc);
+-	  return FAILURE;
+-	}
++  if (c->ts.type == BT_DERIVED && c->ts.u.derived->attr.generic)
++    c->ts.u.derived = gfc_find_dt_in_generic (c->ts.u.derived);
++  else if (c->ts.type == BT_CLASS && c->attr.class_ok
++           && CLASS_DATA (c)->ts.u.derived->attr.generic)
++    CLASS_DATA (c)->ts.u.derived
++                    = gfc_find_dt_in_generic (CLASS_DATA (c)->ts.u.derived);
+ 
+-      if (c->ts.type == BT_CHARACTER && !c->attr.proc_pointer
+-	    && !c->ts.deferred)
+-	{
+-	 if (c->ts.u.cl->length == NULL
+-	     || (resolve_charlen (c->ts.u.cl) == FAILURE)
+-	     || !gfc_is_constant_expr (c->ts.u.cl->length))
+-	   {
+-	     gfc_error ("Character length of component '%s' needs to "
+-			"be a constant specification expression at %L",
+-			c->name,
+-			c->ts.u.cl->length ? &c->ts.u.cl->length->where : &c->loc);
+-	     return FAILURE;
+-	   }
+-	}
++  if (!sym->attr.is_class && c->ts.type == BT_DERIVED && !sym->attr.vtype
++      && c->attr.pointer && c->ts.u.derived->components == NULL
++      && !c->ts.u.derived->attr.zero_comp)
++    {
++      gfc_error ("The pointer component '%s' of '%s' at %L is a type "
++                 "that has not been declared", c->name, sym->name,
++                 &c->loc);
++      return FAILURE;
++    }
+ 
+-      if (c->ts.type == BT_CHARACTER && c->ts.deferred
+-	  && !c->attr.pointer && !c->attr.allocatable)
+-	{
+-	  gfc_error ("Character component '%s' of '%s' at %L with deferred "
+-		     "length must be a POINTER or ALLOCATABLE",
+-		     c->name, sym->name, &c->loc);
+-	  return FAILURE;
+-	}
++  if (c->ts.type == BT_CLASS && c->attr.class_ok
++      && CLASS_DATA (c)->attr.class_pointer
++      && CLASS_DATA (c)->ts.u.derived->components == NULL
++      && !CLASS_DATA (c)->ts.u.derived->attr.zero_comp
++      && !UNLIMITED_POLY (c))
++    {
++      gfc_error ("The pointer component '%s' of '%s' at %L is a type "
++                 "that has not been declared", c->name, sym->name,
++                 &c->loc);
++      return FAILURE;
++    }
+ 
+-      if (c->ts.type == BT_DERIVED
+-	  && sym->component_access != ACCESS_PRIVATE
+-	  && gfc_check_symbol_access (sym)
+-	  && !is_sym_host_assoc (c->ts.u.derived, sym->ns)
+-	  && !c->ts.u.derived->attr.use_assoc
+-	  && !gfc_check_symbol_access (c->ts.u.derived)
+-	  && gfc_notify_std (GFC_STD_F2003, "the component '%s' "
+-			     "is a PRIVATE type and cannot be a component of "
+-			     "'%s', which is PUBLIC at %L", c->name,
+-			     sym->name, &sym->declared_at) == FAILURE)
+-	return FAILURE;
++  /* C437.  */
++  if (c->ts.type == BT_CLASS && c->attr.flavor != FL_PROCEDURE
++      && (!c->attr.class_ok
++          || !(CLASS_DATA (c)->attr.class_pointer
++               || CLASS_DATA (c)->attr.allocatable)))
++    {
++      gfc_error ("Component '%s' with CLASS at %L must be allocatable "
++                 "or pointer", c->name, &c->loc);
++      /* Prevent a recurrence of the error.  */
++      c->ts.type = BT_UNKNOWN;
++      return FAILURE;
++    }
+ 
+-      if ((sym->attr.sequence || sym->attr.is_bind_c) && c->ts.type == BT_CLASS)
+-	{
+-	  gfc_error ("Polymorphic component %s at %L in SEQUENCE or BIND(C) "
+-		     "type %s", c->name, &c->loc, sym->name);
+-	  return FAILURE;
+-	}
++  if (c->ts.type == BT_UNION && resolve_fl_union (c->ts.u.derived) == FAILURE)
++      return FAILURE;
+ 
+-      if (sym->attr.sequence)
+-	{
+-	  if (c->ts.type == BT_DERIVED && c->ts.u.derived->attr.sequence == 0)
+-	    {
+-	      gfc_error ("Component %s of SEQUENCE type declared at %L does "
+-			 "not have the SEQUENCE attribute",
+-			 c->ts.u.derived->name, &sym->declared_at);
+-	      return FAILURE;
+-	    }
+-	}
++  /* Ensure that all the derived type components are put on the
++     derived type list; even in formal namespaces, where derived type
++     pointer components might not have been declared.  */
++  if (c->ts.type == BT_DERIVED
++        && c->ts.u.derived
++        && c->ts.u.derived->components
++        && c->attr.pointer
++        && sym != c->ts.u.derived)
++    add_dt_to_dt_list (c->ts.u.derived);
++
++  if (gfc_resolve_array_spec (c->as, !(c->attr.pointer
++                                       || c->attr.proc_pointer
++                                       || c->attr.allocatable)) == FAILURE)
++    return FAILURE;
+ 
+-      if (c->ts.type == BT_DERIVED && c->ts.u.derived->attr.generic)
+-	c->ts.u.derived = gfc_find_dt_in_generic (c->ts.u.derived);
+-      else if (c->ts.type == BT_CLASS && c->attr.class_ok
+-	       && CLASS_DATA (c)->ts.u.derived->attr.generic)
+-	CLASS_DATA (c)->ts.u.derived
+-			= gfc_find_dt_in_generic (CLASS_DATA (c)->ts.u.derived);
++  if (c->initializer && !sym->attr.vtype
++      && gfc_check_assign_symbol (sym, c, c->initializer) == FAILURE)
++    return FAILURE;
+ 
+-      if (!sym->attr.is_class && c->ts.type == BT_DERIVED && !sym->attr.vtype
+-	  && c->attr.pointer && c->ts.u.derived->components == NULL
+-	  && !c->ts.u.derived->attr.zero_comp)
+-	{
+-	  gfc_error ("The pointer component '%s' of '%s' at %L is a type "
+-		     "that has not been declared", c->name, sym->name,
+-		     &c->loc);
+-	  return FAILURE;
+-	}
++  return SUCCESS;
++}
+ 
+-      if (c->ts.type == BT_CLASS && c->attr.class_ok
+-	  && CLASS_DATA (c)->attr.class_pointer
+-	  && CLASS_DATA (c)->ts.u.derived->components == NULL
+-	  && !CLASS_DATA (c)->ts.u.derived->attr.zero_comp
+-	  && !UNLIMITED_POLY (c))
+-	{
+-	  gfc_error ("The pointer component '%s' of '%s' at %L is a type "
+-		     "that has not been declared", c->name, sym->name,
+-		     &c->loc);
+-	  return FAILURE;
+-	}
++/* Resolve the components of a union type. */
+ 
+-      /* C437.  */
+-      if (c->ts.type == BT_CLASS && c->attr.flavor != FL_PROCEDURE
+-	  && (!c->attr.class_ok
+-	      || !(CLASS_DATA (c)->attr.class_pointer
+-		   || CLASS_DATA (c)->attr.allocatable)))
+-	{
+-	  gfc_error ("Component '%s' with CLASS at %L must be allocatable "
+-		     "or pointer", c->name, &c->loc);
+-	  /* Prevent a recurrence of the error.  */
+-	  c->ts.type = BT_UNKNOWN;
+-	  return FAILURE;
+-	}
++static gfc_try
++resolve_fl_union (gfc_symbol *sym)
++{
++  gfc_component *map;
++  gfc_try success;
+ 
+-      /* Ensure that all the derived type components are put on the
+-	 derived type list; even in formal namespaces, where derived type
+-	 pointer components might not have been declared.  */
+-      if (c->ts.type == BT_DERIVED
+-	    && c->ts.u.derived
+-	    && c->ts.u.derived->components
+-	    && c->attr.pointer
+-	    && sym != c->ts.u.derived)
+-	add_dt_to_dt_list (c->ts.u.derived);
++  gcc_assert (sym->attr.flavor == FL_UNION);
+ 
+-      if (gfc_resolve_array_spec (c->as, !(c->attr.pointer
+-					   || c->attr.proc_pointer
+-					   || c->attr.allocatable)) == FAILURE)
+-	return FAILURE;
++  success = SUCCESS;
++  for (map = sym->components; map; map = map->next)
++  {
++    if (resolve_component (map, (void *)sym) == FAILURE)
++      success = FAILURE;
++  }
+ 
+-      if (c->initializer && !sym->attr.vtype
+-	  && gfc_check_assign_symbol (sym, c, c->initializer) == FAILURE)
+-	return FAILURE;
++  if (success != SUCCESS)
++    return FAILURE;
++
++  if (sym->components)
++    add_dt_to_dt_list (sym);
++
++  return SUCCESS;
++}
++
++/* Resolve the components of a derived type. This does not have to wait until
++   resolution stage, but can be done as soon as the dt declaration has been
++   parsed.  */
++
++static gfc_try
++resolve_fl_derived0 (gfc_symbol *sym)
++{
++  gfc_symbol* super_type;
++  gfc_component *c;
++  gfc_try success;
++
++  if (sym->attr.unlimited_polymorphic)
++    return SUCCESS;
++
++  super_type = gfc_get_derived_super_type (sym);
++
++  /* F2008, C432. */
++  if (super_type && sym->attr.coarray_comp && !super_type->attr.coarray_comp)
++    {
++      gfc_error ("As extending type '%s' at %L has a coarray component, "
++		 "parent type '%s' shall also have one", sym->name,
++		 &sym->declared_at, super_type->name);
++      return FAILURE;
++    }
++
++  /* Ensure the extended type gets resolved before we do.  */
++  if (super_type && resolve_fl_derived0 (super_type) == FAILURE)
++    return FAILURE;
++
++  /* An ABSTRACT type must be extensible.  */
++  if (sym->attr.abstract && !gfc_type_is_extensible (sym))
++    {
++      gfc_error ("Non-extensible derived-type '%s' at %L must not be ABSTRACT",
++		 sym->name, &sym->declared_at);
++      return FAILURE;
+     }
+ 
++  c = (sym->attr.is_class) ? sym->components->ts.u.derived->components
++			   : sym->components;
++
++  /* Resolve all components of this type. */
++  success = SUCCESS;
++  for (; c; c = c->next)
++  {
++    if (resolve_component (c, (void *)sym) == FAILURE)
++      success = FAILURE;
++  }
++
++  if (success != SUCCESS)
++    return FAILURE;
++
+   check_defined_assignments (sym);
+ 
+   if (!sym->attr.defined_assign_comp && super_type)
+@@ -13169,8 +13287,8 @@ resolve_fl_derived (gfc_symbol *sym)
+   if (sym->attr.is_class && sym->ts.u.derived == NULL)
+     {
+       /* Fix up incomplete CLASS symbols.  */
+-      gfc_component *data = gfc_find_component (sym, "_data", true, true);
+-      gfc_component *vptr = gfc_find_component (sym, "_vptr", true, true);
++      gfc_component *data = gfc_find_component (sym, "_data", true, true, NULL);
++      gfc_component *vptr = gfc_find_component (sym, "_vptr", true, true, NULL);
+ 
+       /* Nothing more to do for unlimited polymorphic entities.  */
+       if (data->ts.u.derived->attr.unlimited_polymorphic)
+@@ -13391,6 +13509,11 @@ resolve_symbol (gfc_symbol *sym)
+     return;
+   sym->resolved = 1;
+ 
++  /* No symbol will ever have union type; only components can be unions.
++     Union type declaration symbols have type BT_UNKNOWN but flavor FL_UNION
++     (just like derived type declaration symbols have flavor FL_DERIVED). */
++  gcc_assert (sym->ts.type != BT_UNION);
++
+   if (sym->attr.artificial)
+     return;
+ 
+@@ -13459,7 +13582,11 @@ resolve_symbol (gfc_symbol *sym)
+       return;
+     }
+ 
+-  if (sym->attr.flavor == FL_DERIVED && resolve_fl_derived (sym) == FAILURE)
++  if ((sym->attr.flavor == FL_DERIVED || sym->attr.flavor == FL_STRUCT)
++      && resolve_fl_derived (sym) == FAILURE)
++    return;
++
++  if (sym->attr.flavor == FL_UNION && resolve_fl_union (sym) == FAILURE)
+     return;
+ 
+   /* Symbols that are module procedures with results (functions) have
+@@ -13679,7 +13806,7 @@ resolve_symbol (gfc_symbol *sym)
+      interoperability when a variable is declared of that type.  */
+   if (sym->attr.is_bind_c && sym->attr.implicit_type == 0 &&
+       sym->attr.use_assoc == 0 && sym->attr.dummy == 0 &&
+-      sym->attr.flavor != FL_PROCEDURE && sym->attr.flavor != FL_DERIVED)
++      sym->attr.flavor != FL_PROCEDURE && !gfc_fl_struct (sym->attr.flavor))
+     {
+       gfc_try t = SUCCESS;
+ 
+@@ -14611,8 +14738,7 @@ sequence_type (gfc_typespec ts)
+ 
+   switch (ts.type)
+   {
+-    case BT_DERIVED:
+-
++    case_struct_bt:
+       if (ts.u.derived->components == NULL)
+ 	return SEQ_NONDEFAULT;
+ 
+@@ -14698,7 +14824,7 @@ resolve_equivalence_derived (gfc_symbol *derived, gfc_symbol *sym, gfc_expr *e)
+ 
+   for (; c ; c = c->next)
+     {
+-      if (c->ts.type == BT_DERIVED
++      if (gfc_bt_struct (c->ts.type)
+ 	  && (resolve_equivalence_derived (c->ts.u.derived, sym, e) == FAILURE))
+ 	return FAILURE;
+ 
+diff --git a/gcc/fortran/symbol.c b/gcc/fortran/symbol.c
+index fdd42a8..5f08756 100644
+--- a/gcc/fortran/symbol.c
++++ b/gcc/fortran/symbol.c
+@@ -40,6 +40,7 @@ const mstring flavors[] =
+   minit ("VARIABLE", FL_VARIABLE), minit ("PARAMETER", FL_PARAMETER),
+   minit ("LABEL", FL_LABEL), minit ("PROCEDURE", FL_PROCEDURE),
+   minit ("DERIVED", FL_DERIVED), minit ("NAMELIST", FL_NAMELIST),
++  minit ("UNION", FL_UNION), minit ("STRUCTURE", FL_STRUCT),
+   minit (NULL, -1)
+ };
+ 
+@@ -457,8 +458,8 @@ check_conflict (symbol_attribute *attr, const char *name, locus *where)
+ 	  case FL_BLOCK_DATA:
+ 	  case FL_MODULE:
+ 	  case FL_LABEL:
+-	  case FL_DERIVED:
+ 	  case FL_PARAMETER:
++          case_struct_fl:
+             a1 = gfc_code2string (flavors, attr->flavor);
+             a2 = save;
+ 	    goto conflict;
+@@ -723,7 +724,7 @@ check_conflict (symbol_attribute *attr, const char *name, locus *where)
+ 
+       break;
+ 
+-    case FL_DERIVED:
++    case_struct_fl:
+       conf2 (dummy);
+       conf2 (pointer);
+       conf2 (target);
+@@ -1498,7 +1499,7 @@ gfc_add_flavor (symbol_attribute *attr, sym_flavor f, const char *name,
+ {
+ 
+   if ((f == FL_PROGRAM || f == FL_BLOCK_DATA || f == FL_MODULE
+-       || f == FL_PARAMETER || f == FL_LABEL || f == FL_DERIVED
++       || f == FL_PARAMETER || f == FL_LABEL || gfc_fl_struct (f)
+        || f == FL_NAMELIST) && check_used (attr, name, where))
+     return FAILURE;
+ 
+@@ -1748,7 +1749,7 @@ gfc_add_type (gfc_symbol *sym, gfc_typespec *ts, locus *where)
+   if (flavor == FL_PROGRAM || flavor == FL_BLOCK_DATA || flavor == FL_MODULE
+       || flavor == FL_LABEL
+       || (flavor == FL_PROCEDURE && sym->attr.subroutine)
+-      || flavor == FL_DERIVED || flavor == FL_NAMELIST)
++      || gfc_fl_struct (flavor) || flavor == FL_NAMELIST)
+     {
+       gfc_error ("Symbol '%s' at %L cannot have a type", sym->name, where);
+       return FAILURE;
+@@ -1915,6 +1916,11 @@ gfc_add_component (gfc_symbol *sym, const char *name,
+ {
+   gfc_component *p, *tail;
+ 
++  /* Check for existing components with the same name, but not for union
++     components or containers. Unions and maps are anonymous so they have
++     unique internal names which will never conflict.
++     Don't use gfc_find_component here because it calls gfc_use_derived,
++     but the derived type may not be fully defined yet. */
+   tail = NULL;
+ 
+   for (p = sym->components; p; p = p->next)
+@@ -1930,7 +1936,7 @@ gfc_add_component (gfc_symbol *sym, const char *name,
+     }
+ 
+   if (sym->attr.extension
+-	&& gfc_find_component (sym->components->ts.u.derived, name, true, true))
++	&& gfc_find_component (sym->components->ts.u.derived, name, true, true, NULL))
+     {
+       gfc_error ("Component '%s' at %C already in the parent type "
+ 		 "at %L", name, &sym->components->ts.u.derived->declared_at);
+@@ -2021,7 +2027,7 @@ gfc_use_derived (gfc_symbol *sym)
+       return NULL;
+     }
+ 
+-  if (s == NULL || s->attr.flavor != FL_DERIVED)
++  if (s == NULL || !gfc_fl_struct (s->attr.flavor))
+     goto bad;
+ 
+   /* Get rid of symbol sym, translating all references to s.  */
+@@ -2054,30 +2060,110 @@ bad:
+   return NULL;
+ }
+ 
++   
++static gfc_component *
++find_union_component (gfc_symbol *un, const char *name,
++                      bool noaccess, gfc_ref **ref)
++{
++  gfc_component *m, *check;
++  gfc_ref *sref, *tmp;
++
++  for (m = un->components; m; m = m->next)
++  {
++    check = gfc_find_component (m->ts.u.derived, name, noaccess, true, &tmp);
++    if (check == NULL)
++      continue;
++
++    /* Found it somewhere in m; chain the refs together. */
++    if (ref)
++    {
++      /* Map ref. */
++      sref = gfc_get_ref ();
++      sref->type = REF_COMPONENT;
++      sref->u.c.component = m;
++      sref->u.c.sym = m->ts.u.derived;
++      sref->next = tmp;
++
++      *ref = sref;
++    }
++    /* Other checks (such as access) were done in the recursive calls.
++       Now we are done! */
++    return check;
++  }
++  return NULL;
++}
++
+ 
+ /* Given a derived type node and a component name, try to locate the
+    component structure.  Returns the NULL pointer if the component is
+    not found or the components are private.  If noaccess is set, no access
+-   checks are done.  */
++   checks are done. Unless silent is set, a gfc_error is generated when the
++   component cannot be found or accessed.
++   
++   If ref is not NULL, *ref is set to represent the chain of components
++   required to get to the ultimate component.
++
++   If the component is simply a direct subcomponent, or is inherited from a
++   parent derived type in the given derived type, this is a single ref with its
++   component set to the returned component.
++
++   Otherwise, *ref is constructed as a chain of subcomponents. This occurs
++   when the component is found through an implicit chain of nested union and
++   map components. Unions and maps are "anonymous" substructures in FORTRAN
++   which cannot be explicitly referenced, but the reference chain must be
++   considered as in C for backend translation to correctly compute layouts.
++   (For example, x.a may refer to x->(UNION)->(MAP)->(UNION)->(MAP)->a). */
+ 
+ gfc_component *
+ gfc_find_component (gfc_symbol *sym, const char *name,
+-		    bool noaccess, bool silent)
++		    bool noaccess, bool silent, gfc_ref **ref)
+ {
+-  gfc_component *p;
++  gfc_component *p, *check;
++  gfc_ref *sref = NULL, *tmp = NULL;
+ 
+   if (name == NULL || sym == NULL)
+     return NULL;
+ 
+-  sym = gfc_use_derived (sym);
++  if (sym->attr.flavor == FL_DERIVED)
++    sym = gfc_use_derived (sym);
++  else
++    gcc_assert (gfc_fl_struct (sym->attr.flavor));
+ 
+   if (sym == NULL)
+     return NULL;
+ 
++  /* Handle UNIONs specially. */
++  if (sym->attr.flavor == FL_UNION)
++    return find_union_component (sym, name, noaccess, ref);
++
++  if (ref) *ref = NULL;
+   for (p = sym->components; p; p = p->next)
+-    if (strcmp (p->name, name) == 0)
++  {
++    /* Nest search into union's maps. */
++    if (p->ts.type == BT_UNION)
++    {
++      check = find_union_component (p->ts.u.derived, name, noaccess, &tmp);
++      if (check != NULL)
++      {
++        /* Union ref. */
++        if (ref)
++        {
++          sref = gfc_get_ref ();
++          sref->type = REF_COMPONENT;
++          sref->u.c.component = p;
++          sref->u.c.sym = p->ts.u.derived;
++          sref->next = tmp;
++          *ref = sref;
++        }
++        return check;
++      }
++    }
++    else if (strcmp (p->name, name) == 0)
+       break;
+ 
++    continue;
++  }
++
+   if (p && sym->attr.use_assoc && !noaccess)
+     {
+       bool is_parent_comp = sym->attr.extension && (p == sym->components);
+@@ -2093,12 +2179,14 @@ gfc_find_component (gfc_symbol *sym, const char *name,
+ 	}
+     }
+ 
++  /* Look in the parent type. */
+   if (p == NULL
++        && sym->attr.flavor == FL_DERIVED
+ 	&& sym->attr.extension
+ 	&& sym->components->ts.type == BT_DERIVED)
+     {
+       p = gfc_find_component (sym->components->ts.u.derived, name,
+-			      noaccess, silent);
++			      noaccess, silent, ref);
+       /* Do not overwrite the error.  */
+       if (p == NULL)
+ 	return p;
+@@ -2108,6 +2196,25 @@ gfc_find_component (gfc_symbol *sym, const char *name,
+     gfc_error ("'%s' at %C is not a member of the '%s' structure",
+ 	       name, sym->name);
+ 
++  /* Component was found; build the ultimate component reference. */
++  if (p != NULL && ref)
++  {
++    tmp = gfc_get_ref ();
++    tmp->type = REF_COMPONENT;
++    tmp->u.c.component = p;
++    tmp->u.c.sym = sym;
++    /* Link the final component ref to the end of the chain of subrefs. */
++    if (sref)
++    {
++      *ref = sref;
++      for (; sref->next; sref = sref->next)
++        ;
++      sref->next = tmp;
++    }
++    else
++      *ref = tmp;
++  }
++
+   return p;
+ }
+ 
+@@ -3176,11 +3283,9 @@ gfc_restore_last_undo_checkpoint (void)
+ 	  /* The derived type is saved in the symtree with the first
+ 	     letter capitalized; the all lower-case version to the
+ 	     derived type contains its associated generic function.  */
+-	  if (p->attr.flavor == FL_DERIVED)
+-	    gfc_delete_symtree (&p->ns->sym_root, gfc_get_string ("%c%s",
+-                        (char) TOUPPER ((unsigned char) p->name[0]),
+-                        &p->name[1]));
+-	  else
++	  if (gfc_fl_struct (p->attr.flavor))
++	    gfc_delete_symtree (&p->ns->sym_root,gfc_dt_upper_string (p->name));
++          else
+ 	    gfc_delete_symtree (&p->ns->sym_root, p->name);
+ 
+ 	  gfc_release_symbol (p);
+@@ -3920,7 +4025,7 @@ verify_bind_c_derived_type (gfc_symbol *derived_sym)
+         }
+       
+       /* BIND(C) derived types must have interoperable components.  */
+-      if (curr_comp->ts.type == BT_DERIVED
++      if (gfc_bt_struct (curr_comp->ts.type)
+ 	  && curr_comp->ts.u.derived->ts.is_iso_c != 1 
+           && curr_comp->ts.u.derived != derived_sym)
+         {
+@@ -4609,9 +4714,7 @@ generate_isocbinding_symbol (const char *mod_name, iso_c_binding_symbol s,
+ 	  gfc_component *tmp_comp = NULL;
+ 	  char comp_name[(GFC_MAX_SYMBOL_LEN * 2) + 1];
+ 
+-	  hidden_name = gfc_get_string ("%c%s",
+-			    (char) TOUPPER ((unsigned char) tmp_sym->name[0]),
+-                            &tmp_sym->name[1]);
++	  hidden_name = gfc_dt_upper_string (tmp_sym->name);
+ 
+ 	  /* Generate real derived type.  */
+ 	  tmp_symtree = gfc_find_symtree (gfc_current_ns->sym_root,
+@@ -4972,15 +5075,21 @@ gfc_type_compatible (gfc_typespec *ts1, gfc_typespec *ts2)
+   bool is_class2 = (ts2->type == BT_CLASS);
+   bool is_derived1 = (ts1->type == BT_DERIVED);
+   bool is_derived2 = (ts2->type == BT_DERIVED);
++  bool is_union1 = (ts1->type == BT_UNION);
++  bool is_union2 = (ts2->type == BT_UNION);
+ 
+   if (is_class1
+       && ts1->u.derived->components
+       && ts1->u.derived->components->ts.u.derived->attr.unlimited_polymorphic)
+     return 1;
+ 
+-  if (!is_derived1 && !is_derived2 && !is_class1 && !is_class2)
++  if (!is_derived1 && !is_derived2 && !is_class1 && !is_class2
++      && !is_union1 && !is_union2)
+     return (ts1->type == ts2->type);
+ 
++  if (is_union1 && is_union2)
++    return gfc_compare_union_types (ts1->u.derived, ts2->u.derived);
++
+   if (is_derived1 && is_derived2)
+     return gfc_compare_derived_types (ts1->u.derived, ts2->u.derived);
+ 
+@@ -5039,12 +5148,12 @@ gfc_find_dt_in_generic (gfc_symbol *sym)
+ {
+   gfc_interface *intr = NULL;
+ 
+-  if (!sym || sym->attr.flavor == FL_DERIVED)
++  if (!sym || gfc_fl_struct (sym->attr.flavor))
+     return sym;
+ 
+   if (sym->attr.generic)
+     for (intr = sym->generic; intr; intr = intr->next)
+-      if (intr->sym->attr.flavor == FL_DERIVED)
++      if (gfc_fl_struct (intr->sym->attr.flavor))
+         break;
+   return intr ? intr->sym : NULL;
+ }
+diff --git a/gcc/fortran/target-memory.c b/gcc/fortran/target-memory.c
+index 26a5de2..4fe7d5c 100644
+--- a/gcc/fortran/target-memory.c
++++ b/gcc/fortran/target-memory.c
+@@ -107,8 +107,8 @@ gfc_element_size (gfc_expr *e)
+ 
+     case BT_HOLLERITH:
+       return e->representation.length;
+-    case BT_DERIVED:
+     case BT_CLASS:
++    case_struct_bt:
+       {
+ 	/* Determine type size without clobbering the typespec for ISO C
+ 	   binding types.  */
+@@ -279,6 +279,9 @@ gfc_target_encode_expr (gfc_expr *source, unsigned char *buffer,
+   if (source == NULL)
+     return 0;
+ 
++  /* Assumed no union will end up here. */
++  gcc_assert (source->ts.type != BT_UNION);
++
+   if (source->expr_type == EXPR_ARRAY)
+     return encode_array (source, buffer, buffer_size);
+ 
+@@ -593,6 +596,11 @@ gfc_target_interpret_expr (unsigned char *buffer, size_t buffer_size,
+       gcc_assert (result->representation.length >= 0);
+       break;
+ 
++    /* TODO: Handle BT_UNION ? */
++    case BT_UNION:
++      gfc_warning_now ("Union binary representation unimplemented");
++      break;
++
+     default:
+       gfc_internal_error ("Invalid expression in gfc_target_interpret_expr.");
+       break;
+@@ -639,7 +647,7 @@ expr_to_char (gfc_expr *e, unsigned char *data, unsigned char *chk, size_t len)
+ 
+   /* Take a derived type, one component at a time, using the offsets from the backend
+      declaration.  */
+-  if (e->ts.type == BT_DERIVED)
++  if (gfc_bt_struct (e->ts.type))
+     {
+       for (c = gfc_constructor_first (e->value.constructor),
+ 	   cmp = e->ts.u.derived->components;
+diff --git a/gcc/fortran/trans-decl.c b/gcc/fortran/trans-decl.c
+index 6572794..b803bd3 100644
+--- a/gcc/fortran/trans-decl.c
++++ b/gcc/fortran/trans-decl.c
+@@ -694,22 +694,37 @@ gfc_get_module_backend_decl (gfc_symbol *sym)
+ 	  st->n.sym = sym;
+ 	  sym->refs++;
+ 	}
+-      else if (sym->attr.flavor == FL_DERIVED)
++      else if (gfc_fl_struct (sym->attr.flavor))
+ 	{
+ 	  if (s && s->attr.flavor == FL_PROCEDURE)
+ 	    {
+ 	      gfc_interface *intr;
+ 	      gcc_assert (s->attr.generic);
+ 	      for (intr = s->generic; intr; intr = intr->next)
+-		if (intr->sym->attr.flavor == FL_DERIVED)
++		if (gfc_fl_struct (intr->sym->attr.flavor))
+ 		  {
+ 		    s = intr->sym;
+ 		    break;
+ 		  }
+     	    }
+ 
+-	  if (!s->backend_decl)
+-	    s->backend_decl = gfc_get_derived_type (s);
++           /* Normally we can assume that s is a derived-type symbol since it
++              shares a name with the derived-type sym. However if sym is a
++              STRUCTURE, it may in fact share a name with any other basic type
++              variable. If s is in fact of derived type then we can continue
++              looking for a duplicate type declaration.  */
++           if (sym->attr.flavor == FL_STRUCT && s->ts.type == BT_DERIVED)
++             {
++               s = s->ts.u.derived;
++             }
++
++          if (gfc_fl_struct (s->attr.flavor) && !s->backend_decl)
++          {
++            if (s->attr.flavor == FL_UNION)
++              s->backend_decl = gfc_get_union_type (s);
++            else
++              s->backend_decl = gfc_get_derived_type (s);
++          }
+ 	  gfc_copy_dt_decls_ifequal (s, sym, true);
+ 	  return true;
+ 	}
+@@ -4047,7 +4062,7 @@ gfc_create_module_variable (gfc_symbol * sym)
+       && sym->ts.type == BT_DERIVED)
+     sym->backend_decl = gfc_typenode_for_spec (&(sym->ts));
+ 
+-  if (sym->attr.flavor == FL_DERIVED
++  if (gfc_fl_struct (sym->attr.flavor)
+       && sym->backend_decl
+       && TREE_CODE (sym->backend_decl) == RECORD_TYPE)
+     {
+@@ -4266,7 +4281,7 @@ check_constant_initializer (gfc_expr *expr, gfc_typespec *ts, bool array,
+     }
+   else switch (ts->type)
+     {
+-    case BT_DERIVED:
++    case_struct_bt:
+       if (expr->expr_type != EXPR_STRUCTURE)
+ 	return false;
+       cm = expr->ts.u.derived->components;
+diff --git a/gcc/fortran/trans-expr.c b/gcc/fortran/trans-expr.c
+index 456b2ce..ccb611d 100644
+--- a/gcc/fortran/trans-expr.c
++++ b/gcc/fortran/trans-expr.c
+@@ -1550,6 +1550,7 @@ gfc_conv_component_ref (gfc_se * se, gfc_ref * ref)
+   tree tmp;
+   tree decl;
+   tree field;
++  tree context;
+ 
+   c = ref->u.c.component;
+ 
+@@ -1560,15 +1561,20 @@ gfc_conv_component_ref (gfc_se * se, gfc_ref * ref)
+   field = c->backend_decl;
+   gcc_assert (field && TREE_CODE (field) == FIELD_DECL);
+   decl = se->expr;
++  context = DECL_FIELD_CONTEXT (field);
+ 
+   /* Components can correspond to fields of different containing
+      types, as components are created without context, whereas
+      a concrete use of a component has the type of decl as context.
+      So, if the type doesn't match, we search the corresponding
+      FIELD_DECL in the parent type.  To not waste too much time
+-     we cache this result in norestrict_decl.  */
++     we cache this result in norestrict_decl. 
++     On the other hand, if the context is a UNION or a MAP (a
++     RECORD_TYPE within a UNION_TYPE) always use the given FIELD_DECL. */
+ 
+-  if (DECL_FIELD_CONTEXT (field) != TREE_TYPE (decl))
++  if (context != TREE_TYPE (decl) 
++      && !(   TREE_CODE (TREE_TYPE (field)) == UNION_TYPE /* field is union */
++           || TREE_CODE (context) == UNION_TYPE))         /* field is map */
+     {
+       tree f2 = c->norestrict_decl;
+       if (!f2 || DECL_FIELD_CONTEXT (f2) != TREE_TYPE (decl))
+@@ -5686,8 +5692,8 @@ gfc_conv_initializer (gfc_expr * expr, gfc_typespec * ts, tree type,
+     {
+       switch (ts->type)
+ 	{
+-	case BT_DERIVED:
+ 	case BT_CLASS:
++        case_struct_bt:
+ 	  gfc_init_se (&se, NULL);
+ 	  if (ts->type == BT_CLASS && expr->expr_type == EXPR_NULL)
+ 	    gfc_conv_structure (&se, gfc_class_null_initializer(ts, expr), 1);
+@@ -5831,7 +5837,7 @@ gfc_trans_alloc_subarray_assign (tree dest, gfc_component * cm,
+   gfc_add_modify (&block, dest, se.expr);
+ 
+   /* Deal with arrays of derived types with allocatable components.  */
+-  if (cm->ts.type == BT_DERIVED
++  if (gfc_bt_struct (cm->ts.type)
+ 	&& cm->ts.u.derived->attr.alloc_comp)
+     tmp = gfc_copy_alloc_comp (cm->ts.u.derived,
+ 			       se.expr, dest,
+@@ -6018,7 +6024,7 @@ gfc_trans_subcomponent_assign (tree dest, gfc_component * cm, gfc_expr * expr)
+ 	  gfc_add_expr_to_block (&block, tmp);
+ 	}
+     }
+-  else if (expr->ts.type == BT_DERIVED)
++  else if (gfc_bt_struct (cm->ts.type))
+     {
+       if (expr->expr_type != EXPR_STRUCTURE)
+ 	{
+@@ -6125,6 +6131,23 @@ gfc_conv_structure (gfc_se * se, gfc_expr * expr, int init)
+       return;
+     }
+ 
++  /* Though unions appear to have multiple map components, they must only
++     have a single initializer since each map overlaps. */
++  if (expr->ts.type == BT_UNION)
++  {
++    c = gfc_constructor_first (expr->value.constructor);
++    cm = c->n.component;
++    val = gfc_conv_initializer (c->expr, &expr->ts,
++                                TREE_TYPE (cm->backend_decl),
++                                cm->attr.dimension, cm->attr.pointer,
++                                cm->attr.proc_pointer);
++    val = unshare_expr_without_location (val);
++
++    /* Append it to the constructor list.  */
++    CONSTRUCTOR_APPEND_ELT (v, cm->backend_decl, val);
++    goto finish;
++  }
++
+   cm = expr->ts.u.derived->components;
+ 
+   for (c = gfc_constructor_first (expr->value.constructor);
+@@ -6165,6 +6188,7 @@ gfc_conv_structure (gfc_se * se, gfc_expr * expr, int init)
+ 	  CONSTRUCTOR_APPEND_ELT (v, cm->backend_decl, val);
+ 	}
+     }
++finish:
+   se->expr = build_constructor (type, v);
+   if (init)
+     TREE_CONSTANT (se->expr) = 1;
+@@ -6838,7 +6862,7 @@ gfc_trans_scalar_assign (gfc_se * lse, gfc_se * rse, gfc_typespec ts,
+       gfc_trans_string_copy (&block, llen, lse->expr, ts.kind, rlen,
+ 			     rse->expr, ts.kind);
+     }
+-  else if (ts.type == BT_DERIVED && ts.u.derived->attr.alloc_comp)
++  else if (gfc_bt_struct (ts.type) && ts.u.derived->attr.alloc_comp)
+     {
+       cond = NULL_TREE;
+ 
+@@ -6881,7 +6905,7 @@ gfc_trans_scalar_assign (gfc_se * lse, gfc_se * rse, gfc_typespec ts,
+ 	  gfc_add_expr_to_block (&block, tmp);
+ 	}
+     }
+-  else if (ts.type == BT_DERIVED || ts.type == BT_CLASS)
++  else if (gfc_bt_struct (ts.type) || ts.type == BT_CLASS)
+     {
+       gfc_add_block_to_block (&block, &lse->pre);
+       gfc_add_block_to_block (&block, &rse->pre);
+@@ -7892,7 +7916,7 @@ copyable_array_p (gfc_expr * expr)
+     case BT_CHARACTER:
+       return false;
+ 
+-    case BT_DERIVED:
++    case_struct_bt:
+       return !expr->ts.u.derived->attr.alloc_comp;
+ 
+     default:
+diff --git a/gcc/fortran/trans-io.c b/gcc/fortran/trans-io.c
+index a11453d..d9d3e87 100644
+--- a/gcc/fortran/trans-io.c
++++ b/gcc/fortran/trans-io.c
+@@ -1613,7 +1613,7 @@ transfer_namelist_element (stmtblock_t * block, const char * var_name,
+       gfc_add_expr_to_block (block, tmp);
+     }
+ 
+-  if (ts->type == BT_DERIVED && ts->u.derived->components)
++  if (gfc_bt_struct (ts->type) && ts->u.derived->components)
+     {
+       gfc_component *cmp;
+ 
+@@ -2149,7 +2149,7 @@ transfer_expr (gfc_se * se, gfc_typespec * ts, tree addr_expr, gfc_code * code)
+ 
+       break;
+ 
+-    case BT_DERIVED:
++    case_struct_bt:
+       if (ts->u.derived->components == NULL)
+ 	return;
+ 
+@@ -2268,7 +2268,7 @@ gfc_trans_transfer (gfc_code * code)
+ 	  gcc_assert (ref && ref->type == REF_ARRAY);
+ 	}
+ 
+-      if (expr->ts.type != BT_DERIVED
++      if (!gfc_bt_struct (expr->ts.type)
+ 	    && ref && ref->next == NULL
+ 	    && !is_subref_array (expr))
+ 	{
+diff --git a/gcc/fortran/trans-stmt.c b/gcc/fortran/trans-stmt.c
+index 1d8588d..68cfb65 100644
+--- a/gcc/fortran/trans-stmt.c
++++ b/gcc/fortran/trans-stmt.c
+@@ -5471,7 +5471,7 @@ gfc_trans_deallocate (gfc_code *code)
+ 
+       if (expr->rank || gfc_is_coarray (expr))
+ 	{
+-	  if (expr->ts.type == BT_DERIVED && expr->ts.u.derived->attr.alloc_comp)
++	  if (gfc_bt_struct (expr->ts.type) && expr->ts.u.derived->attr.alloc_comp)
+ 	    {
+ 	      gfc_ref *ref;
+ 	      gfc_ref *last = NULL;
+diff --git a/gcc/fortran/trans-types.c b/gcc/fortran/trans-types.c
+index 30561ee..9430c5a 100644
+--- a/gcc/fortran/trans-types.c
++++ b/gcc/fortran/trans-types.c
+@@ -1100,6 +1100,10 @@ gfc_typenode_for_spec (gfc_typespec * spec)
+ 	basetype = gfc_get_character_type (spec->kind, spec->u.cl);
+       break;
+ 
++    case BT_UNION:
++      basetype = gfc_get_union_type (spec->u.derived);
++      break;
++
+     case BT_DERIVED:
+     case BT_CLASS:
+       basetype = gfc_get_derived_type (spec->u.derived);
+@@ -2323,6 +2327,61 @@ gfc_get_ppc_type (gfc_component* c)
+   return build_pointer_type (build_function_type_list (t, NULL_TREE));
+ }
+ 
++/* Build a tree node for a union type. Requires building each map
++   structure which is an element of the union. */
++
++tree
++gfc_get_union_type (gfc_symbol *un)
++{
++    gfc_component *map = NULL;
++    tree typenode = NULL, map_type = NULL, map_field = NULL;
++    tree *chain = NULL;
++
++    if (un->backend_decl)
++    {
++      if (TYPE_FIELDS (un->backend_decl) || un->attr.proc_pointer_comp)
++        return un->backend_decl;
++      else
++        typenode = un->backend_decl;
++    }
++    else
++    {
++      typenode = make_node (UNION_TYPE);
++      TYPE_NAME (typenode) = get_identifier (un->name);
++    }
++
++    /* Add each contained MAP as a field. */
++    for (map = un->components; map; map = map->next)
++    {
++        gcc_assert (map->ts.type == BT_DERIVED);
++
++        /* The map's type node, which is defined within this union's context. */
++        map_type = gfc_get_derived_type (map->ts.u.derived);
++        TYPE_CONTEXT (map_type) = typenode;
++
++        /* The map field's declaration. */
++        map_field = gfc_add_field_to_struct(typenode, get_identifier(map->name),
++                                            map_type, &chain);
++        if (map->loc.lb)
++          gfc_set_decl_location (map_field, &map->loc);
++        else if (un->declared_at.lb)
++          gfc_set_decl_location (map_field, &un->declared_at);
++
++        DECL_PACKED (map_field) |= TYPE_PACKED (typenode);
++        DECL_NAMELESS(map_field) = true;
++
++        /* We should never clobber another backend declaration for this map,
++           because each map component is unique. */
++        if (!map->backend_decl)
++          map->backend_decl = map_field;
++    }
++
++    un->backend_decl = typenode;
++    gfc_finish_type (typenode);
++
++    return typenode;
++}
++
+ 
+ /* Build a tree node for a derived type.  If there are equal
+    derived types, with different local names, these are built
+@@ -2473,7 +2532,10 @@ gfc_get_derived_type (gfc_symbol * derived)
+     return derived->backend_decl;
+ 
+   /* Build the type member list. Install the newly created RECORD_TYPE
+-     node as DECL_CONTEXT of each FIELD_DECL.  */
++     node as DECL_CONTEXT of each FIELD_DECL. In this case we must go
++     through only the top-level linked list of components so we correctly
++     build UNION_TYPE nodes for BT_UNION components. MAPs and other nested
++     types are built as part of gfc_get_union_type. */
+   for (c = derived->components; c; c = c->next)
+     {
+       if (c->attr.proc_pointer)
+diff --git a/gcc/fortran/trans.c b/gcc/fortran/trans.c
+index d7bdf26..11e76d3 100644
+--- a/gcc/fortran/trans.c
++++ b/gcc/fortran/trans.c
+@@ -1041,7 +1041,7 @@ gfc_build_final_call (gfc_typespec ts, gfc_expr *final_wrapper, gfc_expr *var,
+   if (POINTER_TYPE_P (TREE_TYPE (final_fndecl)))
+     final_fndecl = build_fold_indirect_ref_loc (input_location, final_fndecl);
+ 
+-  if (ts.type == BT_DERIVED)
++  if (gfc_bt_struct (ts.type))
+     {
+       tree elem_size;
+ 
+@@ -1186,7 +1186,7 @@ gfc_deallocate_scalar_with_status (tree pointer, tree status, bool can_fail,
+   gfc_start_block (&non_null);
+ 
+   /* Free allocatable components.  */
+-  if (ts.type == BT_DERIVED && ts.u.derived->attr.alloc_comp)
++  if (gfc_bt_struct (ts.type) && ts.u.derived->attr.alloc_comp)
+     {
+       tmp = build_fold_indirect_ref_loc (input_location, pointer);
+       tmp = gfc_deallocate_alloc_comp (ts.u.derived, tmp, 0);
+-- 
+2.5.0
+

--- a/rhel7/patches/0050-Fixes-to-gfortran.texi.patch
+++ b/rhel7/patches/0050-Fixes-to-gfortran.texi.patch
@@ -1,0 +1,104 @@
+From 36e9c4df5e3e9c0099979ffce69f7210e0d66afe Mon Sep 17 00:00:00 2001
+From: Jim MacArthur <jim.macarthur@codethink.co.uk>
+Date: Wed, 30 Mar 2016 17:11:08 +0100
+Subject: [PATCH 50/55] Fixes to gfortran.texi
+
+---
+ gcc/fortran/gfortran.texi | 36 +++++++++++++++++++++++++++++-------
+ 1 file changed, 29 insertions(+), 7 deletions(-)
+
+diff --git a/gcc/fortran/gfortran.texi b/gcc/fortran/gfortran.texi
+index 451eb59..7b1d9a7 100644
+--- a/gcc/fortran/gfortran.texi
++++ b/gcc/fortran/gfortran.texi
+@@ -1320,10 +1320,10 @@ extensions.
+ 
+ @menu
+ * Extensions implemented in GNU Fortran::
++* Optional DEC extension support::
+ * Extensions not implemented in GNU Fortran::
+ @end menu
+ 
+-
+ @node Extensions implemented in GNU Fortran
+ @section Extensions implemented in GNU Fortran
+ @cindex extensions, implemented
+@@ -1980,7 +1980,7 @@ AUTOMATIC forces all variable declared with it to be on the stack.
+ AUTOMATIC overrides -fno-automatic.
+ 
+ @node Optional DEC extension support
+-@subsection Optional DEC extension support
++@section Optional DEC extension support
+ @cindex extensions, dec
+ 
+ Long long ago in a land far far away, in the time before Fortran standards
+@@ -2002,7 +2002,7 @@ described here.
+ @end menu
+ 
+ @node STRUCTURE and RECORD
+-@subsubsection @code{STRUCTURE} and @code{RECORD}
++@subsection @code{STRUCTURE} and @code{RECORD}
+ @cindex @code{STRUCTURE}
+ @cindex @code{RECORD}
+ 
+@@ -2146,7 +2146,7 @@ those described in @ref{Old-style variable initialization}.
+ @end itemize
+ 
+ @node UNION and MAP
+-@subsubsection @code{UNION} and @code{MAP}
++@subsection @code{UNION} and @code{MAP}
+ @cindex @code{UNION}
+ @cindex @code{MAP}
+ 
+@@ -2247,6 +2247,31 @@ a.rx = z'AABBCCCCFFFFFFFF'
+ !  a.l == z'AA'
+ @end example
+ 
++
++@node Extensions not implemented in GNU Fortran
++@section Extensions not implemented in GNU Fortran
++@cindex extensions, not implemented
++
++The long history of the Fortran language, its wide use and broad
++userbase, the large number of different compiler vendors and the lack of
++some features crucial to users in the first standards have lead to the
++existence of a number of important extensions to the language.  While
++some of the most useful or popular extensions are supported by the GNU
++Fortran compiler, not all existing extensions are supported.  This section
++aims at listing these extensions and offering advice on how best make
++code that uses them running with the GNU Fortran compiler.
++
++@c More can be found here:
++@c   -- http://gcc.gnu.org/onlinedocs/gcc-3.4.6/g77/Missing-Features.html
++@c   -- the list of Fortran and libgfortran bugs closed as WONTFIX:
++@c      http://tinyurl.com/2u4h5y
++
++@menu
++* ENCODE and DECODE statements::
++* Variable FORMAT expressions::
++* Alternate complex function syntax::
++@end menu
++
+ @node ENCODE and DECODE statements
+ @subsection @code{ENCODE} and @code{DECODE} statements
+ @cindex @code{ENCODE}
+@@ -2352,8 +2377,6 @@ well as @code{COMPLEX*16 FUNCTION name()}.  Both are non-standard, legacy
+ extensions.  @command{gfortran} accepts the latter form, which is more
+ common, but not the former.
+ 
+-
+-
+ @c ---------------------------------------------------------------------
+ @c Mixed-Language Programming
+ @c ---------------------------------------------------------------------
+@@ -2374,7 +2397,6 @@ if one links Fortran code compiled by different compilers.  In most cases,
+ use of the C Binding features of the Fortran 2003 standard is sufficient,
+ and their use is highly recommended.
+ 
+-
+ @node Interoperability with C
+ @section Interoperability with C
+ 
+-- 
+2.5.0
+


### PR DESCRIPTION
Port of the gfortran patches 48, 49 & 50 from the previous RHEL6 work with minor corrections to make the patches apply cleanly.
