### PR TITLE
Add legacy fortran patch to dts4

### DIFF
--- a/dts4/devtoolset-4-gcc-5.2.1-2.2.el6.spec
+++ b/dts4/devtoolset-4-gcc-5.2.1-2.2.el6.spec
@@ -261,6 +261,8 @@ Patch2001: doxygen-1.7.1-config.patch
 Patch2002: doxygen-1.7.5-timestamp.patch
 Patch2003: doxygen-1.8.0-rh856725.patch
 
+Patch3000: gcc-dts4-legacy-fortran.patch
+
 %if 0%{?rhel} >= 7
 %global nonsharedver 48
 %else
@@ -636,6 +638,7 @@ cd doxygen-%{doxygen_version}
 %patch2003 -p1 -b .rh856725~
 cd ..
 %endif
+%patch3000 -p1 -b .legacyfortran~
 %endif
 
 echo 'Red Hat %{version}-%{gcc_release}' > gcc/DEV-PHASE

--- a/dts4/patches/gcc-dts4-legacy-fortran.patch
+++ b/dts4/patches/gcc-dts4-legacy-fortran.patch
@@ -1,0 +1,7665 @@
+diff --git a/gcc/fortran/arith.c b/gcc/fortran/arith.c
+index b9c25c1..38c5bb9 100644
+--- a/gcc/fortran/arith.c
++++ b/gcc/fortran/arith.c
+@@ -2266,7 +2266,7 @@ gfc_int2log (gfc_expr *src, int kind)
+ }
+ 
+ 
+-/* Helper function to set the representation in a Hollerith conversion.  
++/* Helper function to set the representation in a Hollerith conversion.
+    This assumes that the ts.type and ts.kind of the result have already
+    been set.  */
+ 
+@@ -2297,6 +2297,37 @@ hollerith2representation (gfc_expr *result, gfc_expr *src)
+ }
+ 
+ 
++/* Helper function to set the representation in a character conversion.
++   This assumes that the ts.type and ts.kind of the result have already
++   been set.  */
++
++static void
++character2representation (gfc_expr *result, gfc_expr *src)
++{
++  int src_len, result_len;
++  int i;
++  src_len = src->value.character.length;
++  result_len = gfc_target_expr_size (result);
++
++  if (src_len > result_len)
++    {
++      gfc_warning (0, "The character constant at %L is too long to convert to %s",
++		   &src->where, gfc_typename(&result->ts));
++    }
++
++  result->representation.string = XCNEWVEC (char, result_len + 1);
++
++  for(i=0;i<MIN (result_len, src_len);i++) {
++    result->representation.string[i] = (char) src->value.character.string[i];
++  }
++
++  if (src_len < result_len)
++    memset (&result->representation.string[src_len], ' ', result_len - src_len);
++
++  result->representation.string[result_len] = '\0'; /* For debugger  */
++  result->representation.length = result_len;
++}
++
+ /* Convert Hollerith to integer. The constant will be padded or truncated.  */
+ 
+ gfc_expr *
+@@ -2312,6 +2343,19 @@ gfc_hollerith2int (gfc_expr *src, int kind)
+   return result;
+ }
+ 
++/* Convert character to integer. The constant will be padded or truncated. */
++
++gfc_expr *
++gfc_character2int (gfc_expr *src, int kind)
++{
++  gfc_expr *result;
++  result = gfc_get_constant_expr (BT_INTEGER, kind, &src->where);
++
++  character2representation (result, src);
++  gfc_interpret_integer (kind, (unsigned char *) result->representation.string,
++			 result->representation.length, result->value.integer);
++  return result;
++}
+ 
+ /* Convert Hollerith to real. The constant will be padded or truncated.  */
+ 
+diff --git a/gcc/fortran/arith.h b/gcc/fortran/arith.h
+index 6f81def..681526a 100644
+--- a/gcc/fortran/arith.h
++++ b/gcc/fortran/arith.h
+@@ -82,6 +82,7 @@ gfc_expr *gfc_hollerith2real (gfc_expr *, int);
+ gfc_expr *gfc_hollerith2complex (gfc_expr *, int);
+ gfc_expr *gfc_hollerith2character (gfc_expr *, int);
+ gfc_expr *gfc_hollerith2logical (gfc_expr *, int);
++gfc_expr *gfc_character2int (gfc_expr *, int);
+ 
+ #endif /* GFC_ARITH_H  */
+ 
+diff --git a/gcc/fortran/check.c b/gcc/fortran/check.c
+index dec431b..7c64af4 100644
+--- a/gcc/fortran/check.c
++++ b/gcc/fortran/check.c
+@@ -845,6 +845,24 @@ gfc_check_allocated (gfc_expr *array)
+ }
+ 
+ 
++/* Attempt to promote types so that both types are equivalent, if possible */
++void
++promote_types(gfc_expr *a, gfc_expr *b)
++{
++  if(a->ts.type == b->ts.type) return;
++  if(a->ts.type == BT_REAL && b->ts.type == BT_INTEGER)
++    {
++      gfc_convert_type_warn (b, &a->ts, 2, 1);
++      return;
++    }
++  if(a->ts.type == BT_INTEGER && b->ts.type == BT_REAL)
++    {
++      gfc_convert_type_warn (a, &b->ts, 2, 1);
++    }
++}
++
++
++
+ /* Common check function where the first argument must be real or
+    integer and the second argument must be the same as the first.  */
+ 
+@@ -854,6 +872,9 @@ gfc_check_a_p (gfc_expr *a, gfc_expr *p)
+   if (!int_or_real_check (a, 0))
+     return false;
+ 
++  if (gfc_option.allow_std & GFC_STD_EXTRA_LEGACY)
++    promote_types(a, p);
++
+   if (a->ts.type != p->ts.type)
+     {
+       gfc_error ("%qs and %qs arguments of %qs intrinsic at %L must "
+@@ -2309,7 +2330,7 @@ gfc_check_ichar_iachar (gfc_expr *c, gfc_expr *kind)
+   else
+     return true;
+ 
+-  if (i != 1)
++  if (i != 1 && !(gfc_option.allow_std & GFC_STD_EXTRA_LEGACY))
+     {
+       gfc_error ("Argument of %s at %L must be of length one",
+ 		 gfc_current_intrinsic, &c->where);
+@@ -2381,9 +2402,13 @@ gfc_check_index (gfc_expr *string, gfc_expr *substring, gfc_expr *back,
+ }
+ 
+ 
++/* This is the check function for the argument to the INT intrinsic */
+ bool
+ gfc_check_int (gfc_expr *x, gfc_expr *kind)
+ {
++  if (gfc_option.allow_std & GFC_STD_EXTRA_LEGACY && x->ts.type == BT_CHARACTER)
++    return true;
++
+   if (!numeric_check (x, 0))
+     return false;
+ 
+@@ -2531,7 +2556,7 @@ gfc_check_kill_sub (gfc_expr *pid, gfc_expr *sig, gfc_expr *status)
+ bool
+ gfc_check_kind (gfc_expr *x)
+ {
+-  if (x->ts.type == BT_DERIVED || x->ts.type == BT_CLASS)
++  if (gfc_bt_struct (x->ts.type) || x->ts.type == BT_CLASS)
+     {
+       gfc_error ("%qs argument of %qs intrinsic at %L must be of "
+ 		 "intrinsic type", gfc_current_intrinsic_arg[0]->name,
+diff --git a/gcc/fortran/class.c b/gcc/fortran/class.c
+index 7990399..c7d759a 100644
+--- a/gcc/fortran/class.c
++++ b/gcc/fortran/class.c
+@@ -78,12 +78,11 @@ insert_component_ref (gfc_typespec *ts, gfc_ref **ref, const char * const name)
+   gcc_assert (ts->type == BT_DERIVED || ts->type == BT_CLASS);
+   type_sym = ts->u.derived;
+ 
+-  new_ref = gfc_get_ref ();
+-  new_ref->type = REF_COMPONENT;
+-  new_ref->next = *ref;
+-  new_ref->u.c.sym = type_sym;
+-  new_ref->u.c.component = gfc_find_component (type_sym, name, true, true);
++  gfc_find_component (type_sym, name, true, true, &new_ref);
+   gcc_assert (new_ref->u.c.component);
++  while (new_ref->next)
++    new_ref = new_ref->next;
++  new_ref->next = *ref;
+ 
+   if (new_ref->next)
+     {
+@@ -206,8 +205,9 @@ gfc_fix_class_refs (gfc_expr *e)
+ void
+ gfc_add_component_ref (gfc_expr *e, const char *name)
+ {
++  gfc_component *c;
+   gfc_ref **tail = &(e->ref);
+-  gfc_ref *next = NULL;
++  gfc_ref *ref, *next = NULL;
+   gfc_symbol *derived = e->symtree->n.sym->ts.u.derived;
+   while (*tail != NULL)
+     {
+@@ -237,14 +237,13 @@ gfc_add_component_ref (gfc_expr *e, const char *name)
+   else
+     /* Avoid losing memory.  */
+     gfc_free_ref_list (*tail);
+-  (*tail) = gfc_get_ref();
+-  (*tail)->next = next;
+-  (*tail)->type = REF_COMPONENT;
+-  (*tail)->u.c.sym = derived;
+-  (*tail)->u.c.component = gfc_find_component (derived, name, true, true);
+-  gcc_assert((*tail)->u.c.component);
++  c = gfc_find_component (derived, name, true, true, tail);
++  gcc_assert(c);
++  for (ref = *tail; ref->next; ref = ref->next)
++    ;
++  ref->next = next;
+   if (!next)
+-    e->ts = (*tail)->u.c.component->ts;
++    e->ts = c->ts;
+ }
+ 
+ 
+@@ -477,8 +476,7 @@ get_unique_type_string (char *string, gfc_symbol *derived)
+   if (derived->attr.unlimited_polymorphic)
+     strcpy (dt_name, "STAR");
+   else
+-    strcpy (dt_name, derived->name);
+-  dt_name[0] = TOUPPER (dt_name[0]);
++    strcpy (dt_name, gfc_dt_upper_string (derived->name));
+   if (derived->attr.unlimited_polymorphic)
+     sprintf (string, "_%s", dt_name);
+   else if (derived->module)
+@@ -751,7 +749,7 @@ add_proc_comp (gfc_symbol *vtype, const char *name, gfc_typebound_proc *tb)
+   if (tb->non_overridable)
+     return;
+ 
+-  c = gfc_find_component (vtype, name, true, true);
++  c = gfc_find_component (vtype, name, true, true, NULL);
+ 
+   if (c == NULL)
+     {
+@@ -820,7 +818,7 @@ copy_vtab_proc_comps (gfc_symbol *declared, gfc_symbol *vtype)
+ 
+   for (cmp = vtab->ts.u.derived->components; cmp; cmp = cmp->next)
+     {
+-      if (gfc_find_component (vtype, cmp->name, true, true))
++      if (gfc_find_component (vtype, cmp->name, true, true, NULL))
+ 	continue;
+ 
+       add_proc_comp (vtype, cmp->name, cmp->tb);
+@@ -2320,7 +2318,8 @@ gfc_find_derived_vtab (gfc_symbol *derived)
+ 		  gfc_set_sym_referenced (def_init);
+ 		  def_init->ts.type = BT_DERIVED;
+ 		  def_init->ts.u.derived = derived;
+-		  def_init->value = gfc_default_initializer (&def_init->ts);
++		  def_init->value = gfc_default_initializer (&def_init->ts,
++                                                             false);
+ 
+ 		  c->initializer = gfc_lval_expr_from_sym (def_init);
+ 		}
+@@ -2407,7 +2406,7 @@ gfc_find_derived_vtab (gfc_symbol *derived)
+ 
+ have_vtype:
+ 	  vtab->ts.u.derived = vtype;
+-	  vtab->value = gfc_default_initializer (&vtab->ts);
++	  vtab->value = gfc_default_initializer (&vtab->ts, false);
+ 	}
+     }
+ 
+@@ -2677,7 +2676,7 @@ find_intrinsic_vtab (gfc_typespec *ts)
+ 	      c->initializer = gfc_get_null_expr (NULL);
+ 	    }
+ 	  vtab->ts.u.derived = vtype;
+-	  vtab->value = gfc_default_initializer (&vtab->ts);
++	  vtab->value = gfc_default_initializer (&vtab->ts, false);
+ 	}
+     }
+ 
+diff --git a/gcc/fortran/decl.c b/gcc/fortran/decl.c
+index c31180d..ebb8553 100644
+--- a/gcc/fortran/decl.c
++++ b/gcc/fortran/decl.c
+@@ -63,6 +63,7 @@ static gfc_typespec current_ts;
+ static symbol_attribute current_attr;
+ static gfc_array_spec *current_as;
+ static int colon_seen;
++static int attr_seen;
+ 
+ /* The current binding label (if any).  */
+ static const char* curr_binding_label;
+@@ -400,13 +401,13 @@ match_data_constant (gfc_expr **result)
+ 
+   if (sym == NULL
+       || (sym->attr.flavor != FL_PARAMETER
+-	  && (!dt_sym || dt_sym->attr.flavor != FL_DERIVED)))
++	  && (!dt_sym || !gfc_fl_struct (dt_sym->attr.flavor))))
+     {
+       gfc_error ("Symbol %qs must be a PARAMETER in DATA statement at %C",
+ 		 name);
+       return MATCH_ERROR;
+     }
+-  else if (dt_sym && dt_sym->attr.flavor == FL_DERIVED)
++  else if (dt_sym && gfc_fl_struct (dt_sym->attr.flavor))
+     return gfc_match_structure_constructor (dt_sym, result);
+ 
+   /* Check to see if the value is an initialization array expression.  */
+@@ -605,6 +606,147 @@ cleanup:
+ 
+ /************************ Declaration statements *********************/
+ 
++/* Like gfc_match_init_expr, but matches a 'clist' (old-style initialization
++   list). The difference here is the expression is a list of constants
++   and is surrounded by '/'. 
++   The typespec ts must match the typespec of the variable which the
++   clist is initializing.
++   The scalar parameter tells whether this should match a scalar
++   initialization or a list of constants corresponding to array elements. */
++match
++gfc_match_clist_expr (gfc_expr **result, gfc_typespec *ts, gfc_array_spec *as)
++{
++  gfc_constructor_base array_head = NULL;
++  gfc_expr *expr = NULL;
++  match m;
++  locus where;
++  mpz_t repeat, size;
++  bool scalar;
++  int cmp;
++
++  gcc_assert (ts);
++
++  mpz_init_set_ui (repeat, 0);
++  mpz_init (size);
++  scalar = !as || !as->rank;
++
++  /* We have already matched "/". Now look for a constant list, as with
++     top_val_list from decl.c, but append the result to an array constructor. */
++  if (gfc_match ("/") == MATCH_YES)
++  {
++    gfc_error ("Empty old style initializer list at %C");
++    goto cleanup;
++  }
++
++  where = gfc_current_locus;
++  for (;;)
++    {
++      m = match_data_constant (&expr);
++      if (m == MATCH_NO)
++        goto syntax;
++      if (m == MATCH_ERROR)
++        goto cleanup;
++
++      /* Found a repeat specification; match again the actual constant. */
++      if (expr->ts.type == BT_INTEGER && gfc_match_char ('*') == MATCH_YES)
++      {
++        if (scalar)
++        {
++          gfc_error ("Invalid scalar initializer at %C");
++          goto cleanup;
++        }
++        mpz_set (repeat, expr->value.integer);
++        gfc_free_expr (expr);
++        expr = NULL;
++
++        m = match_data_constant (&expr);
++        if (m == MATCH_NO)
++          goto syntax;
++        if (m == MATCH_ERROR)
++          goto cleanup;
++      }
++      else
++        mpz_set_ui (repeat, 1);
++
++      if (!scalar)
++      {
++        /* Add the constant initializer as many times as repeated. */
++        for (; mpz_cmp_ui (repeat, 0) > 0; mpz_sub_ui (repeat, repeat, 1))
++        {
++          /* Make sure types of elements match */
++          if(ts && !gfc_compare_types (&expr->ts, ts)
++                && !gfc_convert_type (expr, ts, 1))
++            goto cleanup;
++
++          gfc_constructor_append_expr (&array_head,
++              gfc_copy_expr (expr), &gfc_current_locus);
++        }
++
++        gfc_free_expr (expr);
++      }
++      /* For scalar initializers quit after one element. */
++      else
++      {
++        if(gfc_match_char ('/') != MATCH_YES)
++        {
++          gfc_error ("End of scalar initializer expected at %C");
++          goto cleanup;
++        }
++        break;
++      }
++
++      if (gfc_match_char ('/') == MATCH_YES)
++        break;
++      if (gfc_match_char (',') == MATCH_NO)
++        goto syntax;
++    }
++
++  /* Set up expr as an array constructor. */
++  if (!scalar)
++  {
++    expr = gfc_get_array_expr (ts->type, ts->kind, &where);
++    expr->ts = *ts;
++    expr->value.constructor = array_head;
++
++    expr->rank = as->rank;
++    expr->shape = gfc_get_shape (expr->rank);
++
++    /* Validate sizes. */
++    gcc_assert (gfc_array_size (expr, &size));
++    gcc_assert (spec_size (as, &repeat));
++    cmp = mpz_cmp (size, repeat);
++    if (cmp < 0)
++      gfc_error ("Not enough elements in array initializer at %C");
++    else if (cmp > 0)
++      gfc_error ("Too many elements in array initializer at %C");
++    if (cmp)
++      goto cleanup;
++  }
++
++  /* Make sure scalar types match. */
++  else if (!gfc_compare_types (&expr->ts, ts)
++           && !gfc_convert_type (expr, ts, 1))
++    goto cleanup;
++
++  if (expr->ts.u.cl)
++    expr->ts.u.cl->length_from_typespec = 1;
++
++  *result = expr;
++  mpz_clear (size);
++  mpz_clear (repeat);
++  return MATCH_YES;
++
++syntax:
++  gfc_error ("Syntax error in old style initializer list at %C");
++
++cleanup:
++  gfc_constructor_free (array_head);
++  expr->value.constructor = NULL;
++  gfc_free_expr (expr);
++  mpz_clear (size);
++  mpz_clear (repeat);
++  return MATCH_ERROR;
++}
+ 
+ /* Auxiliary function to merge DIMENSION and CODIMENSION array specs.  */
+ 
+@@ -803,6 +945,24 @@ syntax:
+   return MATCH_ERROR;
+ }
+ 
++/* This matches the nonstandard kind given after a variable name, like:
++   INTEGER x*2, y*4
++   The per-variable kind will override any kind given in the type
++   declaration.
++*/
++
++static match
++match_per_symbol_kind (int *length)
++{
++  match m;
++
++  m = gfc_match_char ('*');
++  if (m != MATCH_YES)
++    return m;
++
++  m = gfc_match_small_literal_int (length, NULL);
++  return m;
++}
+ 
+ /* Special subroutine for finding a symbol.  Check if the name is found
+    in the current name space.  If not, and we're compiling a function or
+@@ -1373,7 +1533,7 @@ add_init_expr_to_sym (const char *name, gfc_expr **initp, locus *var_locus)
+ 
+       /* Check if the assignment can happen. This has to be put off
+ 	 until later for derived type variables and procedure pointers.  */
+-      if (sym->ts.type != BT_DERIVED && init->ts.type != BT_DERIVED
++      if (!gfc_bt_struct (sym->ts.type) && !gfc_bt_struct (init->ts.type)
+ 	  && sym->ts.type != BT_CLASS && init->ts.type != BT_CLASS
+ 	  && !sym->attr.proc_pointer
+ 	  && !gfc_check_assign_symbol (sym, NULL, init))
+@@ -1491,7 +1651,7 @@ add_init_expr_to_sym (const char *name, gfc_expr **initp, locus *var_locus)
+ 	 If we mark my_int as iso_c (since we can see it's value
+ 	 is equal to one of the named constants), then my_int_2
+ 	 will be considered C interoperable.  */
+-      if (sym->ts.type != BT_CHARACTER && sym->ts.type != BT_DERIVED)
++      if (sym->ts.type != BT_CHARACTER && !gfc_bt_struct (sym->ts.type))
+ 	{
+ 	  sym->ts.is_iso_c |= init->ts.is_iso_c;
+ 	  sym->ts.is_c_interop |= init->ts.is_c_interop;
+@@ -1549,6 +1709,7 @@ static bool
+ build_struct (const char *name, gfc_charlen *cl, gfc_expr **init,
+ 	      gfc_array_spec **as)
+ {
++  gfc_state_data *s;
+   gfc_component *c;
+   bool t = true;
+ 
+@@ -1572,7 +1733,33 @@ build_struct (const char *name, gfc_charlen *cl, gfc_expr **init,
+ 	}
+     }
+ 
+-  if (!gfc_add_component (gfc_current_block(), name, &c))
++  /* If we are in a nested union/map definition, gfc_add_component will not
++     properly find repeated components because they are implicitly chained.
++     Since union and map blocks are not actually linked as components of their
++     parent structures until after they are parsed, we must traverse up the
++     parse stack until we find the top level structure declaration, searching
++     for the component in each block along the way. */
++  s = gfc_state_stack;
++  if (s->state == COMP_UNION || s->state == COMP_MAP)
++  {
++    while (s->state == COMP_UNION || s->state == COMP_MAP
++           || gfc_comp_is_derived (s->state))
++    {
++      c = gfc_find_component (s->sym, name, true, true, NULL);
++      if (c != NULL)
++      {
++        gfc_error_now ("Component '%s' at %C already declared at %L",
++                       name, &c->loc);
++        return false;
++      }
++      /* Break after we've searched the ultimate parent of the current union. */
++      if (s->state == COMP_DERIVED || s->state == COMP_STRUCTURE)
++        break;
++      s = s->previous;
++    }
++  }
++
++  if (!gfc_add_component (gfc_current_block (), name, &c))
+     return false;
+ 
+   c->ts = current_ts;
+@@ -1593,51 +1780,7 @@ build_struct (const char *name, gfc_charlen *cl, gfc_expr **init,
+     }
+   *as = NULL;
+ 
+-  /* Should this ever get more complicated, combine with similar section
+-     in add_init_expr_to_sym into a separate function.  */
+-  if (c->ts.type == BT_CHARACTER && !c->attr.pointer && c->initializer
+-      && c->ts.u.cl
+-      && c->ts.u.cl->length && c->ts.u.cl->length->expr_type == EXPR_CONSTANT)
+-    {
+-      int len;
+-
+-      gcc_assert (c->ts.u.cl && c->ts.u.cl->length);
+-      gcc_assert (c->ts.u.cl->length->expr_type == EXPR_CONSTANT);
+-      gcc_assert (c->ts.u.cl->length->ts.type == BT_INTEGER);
+-
+-      len = mpz_get_si (c->ts.u.cl->length->value.integer);
+-
+-      if (c->initializer->expr_type == EXPR_CONSTANT)
+-	gfc_set_constant_character_len (len, c->initializer, -1);
+-      else if (mpz_cmp (c->ts.u.cl->length->value.integer,
+-			c->initializer->ts.u.cl->length->value.integer))
+-	{
+-	  gfc_constructor *ctor;
+-	  ctor = gfc_constructor_first (c->initializer->value.constructor);
+-
+-	  if (ctor)
+-	    {
+-	      int first_len;
+-	      bool has_ts = (c->initializer->ts.u.cl
+-			     && c->initializer->ts.u.cl->length_from_typespec);
+-
+-	      /* Remember the length of the first element for checking
+-		 that all elements *in the constructor* have the same
+-		 length.  This need not be the length of the LHS!  */
+-	      gcc_assert (ctor->expr->expr_type == EXPR_CONSTANT);
+-	      gcc_assert (ctor->expr->ts.type == BT_CHARACTER);
+-	      first_len = ctor->expr->value.character.length;
+-
+-	      for ( ; ctor; ctor = gfc_constructor_next (ctor))
+-		if (ctor->expr->expr_type == EXPR_CONSTANT)
+-		{
+-		  gfc_set_constant_character_len (len, ctor->expr,
+-						  has_ts ? -1 : first_len);
+-		  ctor->expr->ts.u.cl->length = gfc_copy_expr (c->ts.u.cl->length);
+-		}
+-	    }
+-	}
+-    }
++  gfc_apply_init (&c->ts, &c->attr, c->initializer);
+ 
+   /* Check array components.  */
+   if (!c->attr.dimension)
+@@ -1751,7 +1894,7 @@ match_pointer_init (gfc_expr **init, int procptr)
+ {
+   match m;
+ 
+-  if (gfc_pure (NULL) && gfc_state_stack->state != COMP_DERIVED)
++  if (gfc_pure (NULL) && !gfc_comp_is_derived(gfc_state_stack->state))
+     {
+       gfc_error ("Initialization of pointer at %C is not allowed in "
+ 		 "a PURE procedure");
+@@ -1813,6 +1956,35 @@ check_function_name (char *name)
+ }
+ 
+ 
++static match
++match_character_length_clause (gfc_charlen **cl, bool *cl_deferred, int elem)
++{
++  gfc_expr* char_len;
++  char_len = NULL;
++
++  match m = match_char_length (&char_len, cl_deferred, false);
++  if (m == MATCH_YES)
++    {
++      *cl = gfc_new_charlen (gfc_current_ns, NULL);
++      (*cl)->length = char_len;
++    }
++  else if (m == MATCH_NO)
++    {
++      if (elem > 1
++	  && (current_ts.u.cl->length == NULL
++	      || current_ts.u.cl->length->expr_type != EXPR_CONSTANT))
++	{
++	  *cl = gfc_new_charlen (gfc_current_ns, NULL);
++	  (*cl)->length = gfc_copy_expr (current_ts.u.cl->length);
++	}
++      else
++      *cl = current_ts.u.cl;
++
++      *cl_deferred = current_ts.deferred;
++    }
++  return m;
++}
++
+ /* Match a variable name with an optional initializer.  When this
+    subroutine is called, a variable is expected to be parsed next.
+    Depending on what is happening at the moment, updates either the
+@@ -1822,6 +1994,7 @@ static match
+ variable_decl (int elem)
+ {
+   char name[GFC_MAX_SYMBOL_LEN + 1];
++  static int fill_id = 0;
+   gfc_expr *initializer, *char_len;
+   gfc_array_spec *as;
+   gfc_array_spec *cp_as; /* Extra copy for Cray Pointees.  */
+@@ -1831,20 +2004,81 @@ variable_decl (int elem)
+   match m;
+   bool t;
+   gfc_symbol *sym;
++  match cl_match;
++  match kind_match;
++  int overridden_kind;
+ 
+   initializer = NULL;
+   as = NULL;
+   cp_as = NULL;
++  kind_match = MATCH_NO;
+ 
+   /* When we get here, we've just matched a list of attributes and
+      maybe a type and a double colon.  The next thing we expect to see
+      is the name of the symbol.  */
+-  m = gfc_match_name (name);
++
++  /* If we are parsing a structure, we allow the name of the symbol to
++     be '%FILL', which gives it an anonymous (inaccessible) name. */
++  m = MATCH_NO;
++  gfc_gobble_whitespace ();
++  if (gfc_peek_ascii_char () == '%')
++  {
++    gfc_next_ascii_char ();
++    m = gfc_match ("fill");
++  }
+   if (m != MATCH_YES)
+-    goto cleanup;
++  {
++    m = gfc_match_name (name);
++    if (m != MATCH_YES)
++      goto cleanup;
++  }
++  else 
++  {
++    m = MATCH_ERROR;
++    if (!gfc_option.flag_dec_structure)
++    {
++      gfc_error ("%%FILL at %C is an extension, enable with -fdec-structure");
++      goto cleanup;
++    }
++    if (gfc_current_state () != COMP_STRUCTURE)
++    {
++      gfc_error ("Unnamed field at %C only allowed in a STRUCTURE block");
++      goto cleanup;
++    }
++    if (attr_seen)
++    {
++      gfc_error ("Unnamed field at %C may not have attributes");
++      goto cleanup;
++    }
++    /* The unique anonymous name is an invalid fortran identifier. */
++    sprintf (name, "%%FILL%d", fill_id++);
++    m = MATCH_YES;
++  }
+ 
+   var_locus = gfc_current_locus;
+ 
++
++  cl = NULL;
++  cl_deferred = false;
++  cl_match = MATCH_NO;
++
++  /* Check for a character length clause before an array clause */
++  if (gfc_option.allow_std & GFC_STD_EXTRA_LEGACY)
++    {
++      if (current_ts.type == BT_CHARACTER)
++	{
++	  cl_match = match_character_length_clause( &cl, &cl_deferred, elem );
++	  if (cl_match == MATCH_ERROR)
++	    goto cleanup;
++	}
++      else
++	{
++	  kind_match = match_per_symbol_kind ( &overridden_kind );
++	  if (kind_match == MATCH_ERROR)
++	    goto cleanup;
++	}
++    }
++
+   /* Now we could see the optional array spec. or character length.  */
+   m = gfc_match_array_spec (&as, true, true);
+   if (m == MATCH_ERROR)
+@@ -1889,46 +2123,27 @@ variable_decl (int elem)
+ 	}
+     }
+ 
+-  char_len = NULL;
+-  cl = NULL;
+-  cl_deferred = false;
+-
+-  if (current_ts.type == BT_CHARACTER)
++  /* Second chance for a character length clause */
++  if (cl_match == MATCH_NO && current_ts.type == BT_CHARACTER)
+     {
+-      switch (match_char_length (&char_len, &cl_deferred, false))
+-	{
+-	case MATCH_YES:
+-	  cl = gfc_new_charlen (gfc_current_ns, NULL);
+-
+-	  cl->length = char_len;
+-	  break;
+-
+-	/* Non-constant lengths need to be copied after the first
+-	   element.  Also copy assumed lengths.  */
+-	case MATCH_NO:
+-	  if (elem > 1
+-	      && (current_ts.u.cl->length == NULL
+-		  || current_ts.u.cl->length->expr_type != EXPR_CONSTANT))
+-	    {
+-	      cl = gfc_new_charlen (gfc_current_ns, NULL);
+-	      cl->length = gfc_copy_expr (current_ts.u.cl->length);
+-	    }
+-	  else
+-	    cl = current_ts.u.cl;
+-
+-	  cl_deferred = current_ts.deferred;
+-
+-	  break;
+-
+-	case MATCH_ERROR:
+-	  goto cleanup;
+-	}
++      m = match_character_length_clause( &cl, &cl_deferred, elem );
++      if (m == MATCH_ERROR)
++	goto cleanup;
+     }
+ 
++  /* Fill components may not have initializers. */
++  if (name[0] == '%' && gfc_match_eos () != MATCH_YES) 
++  {
++    gfc_error ("Unnamed field at %C may not have initializers");
++    m = MATCH_ERROR;
++    goto cleanup;
++  }
++
+   /*  If this symbol has already shown up in a Cray Pointer declaration,
+       and this is not a component declaration,
+       then we want to set the type & bail out.  */
+-  if (flag_cray_pointer && gfc_current_state () != COMP_DERIVED)
++  if (flag_cray_pointer
++      && !gfc_comp_is_derived (gfc_current_state ()))
+     {
+       gfc_find_symbol (name, gfc_current_ns, 1, &sym);
+       if (sym != NULL && sym->attr.cray_pointee)
+@@ -1993,13 +2208,20 @@ variable_decl (int elem)
+      For components of derived types, it is not true, so we don't
+      create a symbol for those yet.  If we fail to create the symbol,
+      bail out.  */
+-  if (gfc_current_state () != COMP_DERIVED
++  if (!gfc_comp_is_derived (gfc_current_state ())
+       && !build_sym (name, cl, cl_deferred, &as, &var_locus))
+     {
+       m = MATCH_ERROR;
+       goto cleanup;
+     }
+ 
++  if ( kind_match == MATCH_YES )
++    {
++      gfc_find_symbol (name, gfc_current_ns, 1, &sym);
++      /* sym *must* be found at this point */
++      sym->ts.kind = overridden_kind;
++    }
++
+   if (!check_function_name (name))
+     {
+       m = MATCH_ERROR;
+@@ -2020,17 +2242,52 @@ variable_decl (int elem)
+       if (!gfc_notify_std (GFC_STD_GNU, "Old-style "
+ 			   "initialization at %C"))
+ 	return MATCH_ERROR;
++
+       else if (gfc_current_state () == COMP_DERIVED)
+ 	{
+-	  gfc_error ("Invalid old style initialization for derived type "
+-		     "component at %C");
+-	  m = MATCH_ERROR;
+-	  goto cleanup;
++	  if(gfc_option.allow_std & GFC_STD_EXTRA_LEGACY)
++	    {
++	      /* Attempt to match an old-style initializer which is a simple
++		 integer or character expression; this will not work with
++		 multiple values. */
++	      m = gfc_match_init_expr (&initializer);
++	      if (m == MATCH_ERROR)
++		goto cleanup;
++	      else if (m == MATCH_YES)
++		{
++		  m = gfc_match ("/");
++		  if (m != MATCH_YES)
++		    goto cleanup;
++		}
++	    }
++	  else
++
++	    {
++	      gfc_error ("Invalid old style initialization for derived type "
++			 "component at %C");
++	      m = MATCH_ERROR;
++	      goto cleanup;
++	    }
++	}
++      /* For derived type components, read the initializer as a special
++         expression and let the rest of this function apply the initializer
++         as usual. */
++      else if (gfc_comp_is_derived (gfc_current_state ()))
++	{
++	  m = gfc_match_clist_expr (&initializer, &current_ts, as);
++	  if (m == MATCH_NO)
++	    gfc_error ("Syntax error in old style initialization of "
++		       "structure component %s at %C", name);
++	  if (m != MATCH_YES)
++	    goto cleanup;
+ 	}
+ 
+-      return match_old_style_init (name);
++      /* Otherwise we treat the old style initialization just like a
++         DATA declaration for the current variable. */
++      else
++        return match_old_style_init (name);
+     }
+-
++  
+   /* The double colon must be present in order to have initializers.
+      Otherwise the statement is ambiguous with an assignment statement.  */
+   if (colon_seen)
+@@ -2066,7 +2323,7 @@ variable_decl (int elem)
+ 	    }
+ 
+ 	  if (current_attr.flavor != FL_PARAMETER && gfc_pure (NULL)
+-	      && gfc_state_stack->state != COMP_DERIVED)
++	      && !gfc_comp_is_derived (gfc_state_stack->state))
+ 	    {
+ 	      gfc_error ("Initialization of variable at %C is not allowed in "
+ 			 "a PURE procedure");
+@@ -2074,7 +2331,7 @@ variable_decl (int elem)
+ 	    }
+ 
+ 	  if (current_attr.flavor != FL_PARAMETER
+-	      && gfc_state_stack->state != COMP_DERIVED)
++	      && !gfc_comp_is_derived(gfc_state_stack->state))
+ 	    gfc_unset_implicit_pure (gfc_current_ns->proc_name);
+ 
+ 	  if (m != MATCH_YES)
+@@ -2083,7 +2340,7 @@ variable_decl (int elem)
+     }
+ 
+   if (initializer != NULL && current_attr.allocatable
+-	&& gfc_current_state () == COMP_DERIVED)
++	&& gfc_comp_is_derived (gfc_current_state ()))
+     {
+       gfc_error ("Initialization of allocatable component at %C is not "
+ 		 "allowed");
+@@ -2094,14 +2351,20 @@ variable_decl (int elem)
+   /* Add the initializer.  Note that it is fine if initializer is
+      NULL here, because we sometimes also need to check if a
+      declaration *must* have an initialization expression.  */
+-  if (gfc_current_state () != COMP_DERIVED)
++  if (!gfc_comp_is_derived (gfc_current_state ()))
+     t = add_init_expr_to_sym (name, &initializer, &var_locus);
+   else
+     {
+       if (current_ts.type == BT_DERIVED
+ 	  && !current_attr.pointer && !initializer)
+-	initializer = gfc_default_initializer (&current_ts);
++	initializer = gfc_default_initializer (&current_ts, false);
+       t = build_struct (name, cl, &initializer, &as);
++
++      /* If we match a nested structure definition we expect to see the
++         body even if the component declarations blow up, so we need to keep
++         the structure type around.  */
++      if (gfc_new_block && gfc_new_block->attr.flavor == FL_STRUCT)
++        gfc_commit_symbol (gfc_new_block);
+     }
+ 
+   m = (t) ? MATCH_YES : MATCH_ERROR;
+@@ -2589,6 +2852,35 @@ done:
+   return MATCH_YES;
+ }
+ 
++/* Matches a RECORD declaration. */
++
++static match
++match_record_decl(const char *name)
++{
++    locus old_loc;
++    old_loc = gfc_current_locus;
++
++    if (gfc_match (" record") == MATCH_YES)
++    {
++        if (!gfc_option.flag_dec_structure)
++        {
++            gfc_current_locus = old_loc;
++            gfc_error ("RECORD at %C is a DEC extension, enable with "
++                       "-fdec-structure");
++            return MATCH_ERROR;
++        }
++        if (gfc_match (" /%n/", name) != MATCH_YES)
++        {
++            gfc_error ("Expected \"/field-name/\" after RECORD at %C");
++            gfc_current_locus = old_loc;
++            return MATCH_ERROR;
++        }
++        return MATCH_YES;
++    }
++
++    gfc_current_locus = old_loc;
++    return MATCH_NO;
++}
+ 
+ /* Matches a declaration-type-spec (F03:R502).  If successful, sets the ts
+    structure to the matched specification.  This is necessary for FUNCTION and
+@@ -2647,7 +2939,7 @@ gfc_match_decl_type_spec (gfc_typespec *ts, int implicit_flag)
+ 	{
+ 	  if ((m = gfc_match ("*)")) != MATCH_YES)
+ 	    return m;
+-	  if (gfc_current_state () == COMP_DERIVED)
++	  if (gfc_comp_is_derived (gfc_current_state ()))
+ 	    {
+ 	      gfc_error ("Assumed type at %C is not allowed for components");
+ 	      return MATCH_ERROR;
+@@ -2759,9 +3051,57 @@ gfc_match_decl_type_spec (gfc_typespec *ts, int implicit_flag)
+     m = gfc_match_char (')');
+ 
+   if (m == MATCH_YES)
++  {
+     ts->type = BT_DERIVED;
++    /* Don't need all the extra derived-type stuff for structures. */
++    if (gfc_find_symbol (gfc_dt_upper_string (name), NULL, 1, &sym))
++    {
++      gfc_error ("Type name '%s' at %C is ambiguous", name);
++      return MATCH_ERROR;
++    }
++    if (sym && sym->attr.flavor == FL_STRUCT)
++    {
++      ts->u.derived = sym;
++      return MATCH_YES;
++    }
++  }
+   else
+     {
++      /* Match RECORD declarations. */
++      m = match_record_decl (name);
++      if (m == MATCH_YES)
++      {
++        ts->type = BT_DERIVED;
++        /* Don't need all the extra derived-type stuff for structures. */
++        if (gfc_find_symbol (gfc_dt_upper_string (name), NULL, 1, &sym))
++        {
++          gfc_error ("Type name '%s' at %C is ambiguous", name);
++          return MATCH_ERROR;
++        }
++        if (sym && sym->attr.flavor == FL_STRUCT)
++        {
++          ts->u.derived = sym;
++          return MATCH_YES;
++        }
++        goto derived;
++      }
++
++      /* Match ad-hoc STRUCTURE declarations; only valid within another
++         derived/structure declaration. */
++      m = gfc_match (" structure");
++      if (m == MATCH_YES && gfc_comp_is_derived (gfc_current_state ()))
++      {
++        m = gfc_match_structure_decl ();
++        if (m == MATCH_YES)
++        {
++          /* gfc_new_block updated by match_structure_decl() */
++          ts->type = BT_DERIVED;
++          ts->u.derived = gfc_new_block;
++          return MATCH_YES;
++        }
++        return MATCH_ERROR;
++      }
++
+       /* Match CLASS declarations.  */
+       m = gfc_match (" class ( * )");
+       if (m == MATCH_ERROR)
+@@ -2809,6 +3149,7 @@ gfc_match_decl_type_spec (gfc_typespec *ts, int implicit_flag)
+ 	return MATCH_ERROR;
+     }
+ 
++derived:
+   /* Defer association of the derived type until the end of the
+      specification block.  However, if the derived type can be
+      found, add it to the typespec.  */
+@@ -2830,9 +3171,7 @@ gfc_match_decl_type_spec (gfc_typespec *ts, int implicit_flag)
+      stored in a symtree with the first letter of the name capitalized; the
+      symtree with the all lower-case name contains the associated
+      generic function.  */
+-  dt_name = gfc_get_string ("%c%s",
+-			    (char) TOUPPER ((unsigned char) name[0]),
+-			    (const char*)&name[1]);
++  dt_name = gfc_dt_upper_string (name);
+   sym = NULL;
+   dt_sym = NULL;
+   if (ts->kind != -1)
+@@ -2864,7 +3203,7 @@ gfc_match_decl_type_spec (gfc_typespec *ts, int implicit_flag)
+ 	return MATCH_NO;
+     }
+ 
+-  if ((sym->attr.flavor != FL_UNKNOWN
++  if ((sym->attr.flavor != FL_UNKNOWN && sym->attr.flavor != FL_STRUCT
+        && !(sym->attr.flavor == FL_PROCEDURE && sym->attr.generic))
+       || sym->attr.subroutine)
+     {
+@@ -2904,7 +3243,7 @@ gfc_match_decl_type_spec (gfc_typespec *ts, int implicit_flag)
+ 
+   gfc_set_sym_referenced (dt_sym);
+ 
+-  if (dt_sym->attr.flavor != FL_DERIVED
++  if (dt_sym->attr.flavor != FL_DERIVED && dt_sym->attr.flavor != FL_STRUCT
+       && !gfc_add_flavor (&dt_sym->attr, FL_DERIVED, sym->name, NULL))
+     return MATCH_ERROR;
+ 
+@@ -3335,9 +3674,7 @@ gfc_match_import (void)
+ 		 letter of the name capitalized; the symtree with the all
+ 		 lower-case name contains the associated generic function.  */
+ 	      st = gfc_new_symtree (&gfc_current_ns->sym_root,
+-			gfc_get_string ("%c%s",
+-				(char) TOUPPER ((unsigned char) name[0]),
+-				&name[1]));
++                                    gfc_dt_upper_string (name));
+ 	      st->n.sym = sym;
+ 	      sym->refs++;
+ 	      sym->attr.imported = 1;
+@@ -3401,9 +3738,9 @@ match_attr_spec (void)
+     DECL_ALLOCATABLE = GFC_DECL_BEGIN, DECL_DIMENSION, DECL_EXTERNAL,
+     DECL_IN, DECL_OUT, DECL_INOUT, DECL_INTRINSIC, DECL_OPTIONAL,
+     DECL_PARAMETER, DECL_POINTER, DECL_PROTECTED, DECL_PRIVATE,
+-    DECL_PUBLIC, DECL_SAVE, DECL_TARGET, DECL_VALUE, DECL_VOLATILE,
+-    DECL_IS_BIND_C, DECL_CODIMENSION, DECL_ASYNCHRONOUS, DECL_CONTIGUOUS,
+-    DECL_NONE, GFC_DECL_END /* Sentinel */
++    DECL_PUBLIC, DECL_SAVE, DECL_AUTOMATIC, DECL_TARGET, DECL_VALUE,
++    DECL_VOLATILE, DECL_IS_BIND_C, DECL_CODIMENSION, DECL_ASYNCHRONOUS,
++    DECL_CONTIGUOUS, DECL_NONE, GFC_DECL_END /* Sentinel */
+   };
+ 
+ /* GFC_DECL_END is the sentinel, index starts at 0.  */
+@@ -3421,6 +3758,7 @@ match_attr_spec (void)
+ 
+   current_as = NULL;
+   colon_seen = 0;
++  attr_seen = 0;
+ 
+   /* See if we get all of the keywords up to the final double colon.  */
+   for (d = GFC_DECL_BEGIN; d != GFC_DECL_END; d++)
+@@ -3464,6 +3802,14 @@ match_attr_spec (void)
+ 		      d = DECL_ASYNCHRONOUS;
+ 		    }
+ 		  break;
++
++		case 'u':
++		  if (match_string_p ("tomatic"))
++		    {
++		      /* Matched "automatic".  */
++		      d = DECL_AUTOMATIC;
++		    }
++		  break;
+ 		}
+ 	      break;
+ 
+@@ -3730,6 +4076,9 @@ match_attr_spec (void)
+ 	  case DECL_SAVE:
+ 	    attr = "SAVE";
+ 	    break;
++	  case DECL_AUTOMATIC:
++	    attr = "AUTOMATIC";
++	    break;
+ 	  case DECL_TARGET:
+ 	    attr = "TARGET";
+ 	    break;
+@@ -3757,8 +4106,10 @@ match_attr_spec (void)
+     {
+       if (seen[d] == 0)
+ 	continue;
++      else
++        attr_seen = 1;
+ 
+-      if (gfc_current_state () == COMP_DERIVED
++      if (gfc_comp_is_derived (gfc_current_state ())
+ 	  && d != DECL_DIMENSION && d != DECL_CODIMENSION
+ 	  && d != DECL_POINTER   && d != DECL_PRIVATE
+ 	  && d != DECL_PUBLIC && d != DECL_CONTIGUOUS && d != DECL_NONE)
+@@ -3766,7 +4117,8 @@ match_attr_spec (void)
+ 	  if (d == DECL_ALLOCATABLE)
+ 	    {
+ 	      if (!gfc_notify_std (GFC_STD_F2003, "ALLOCATABLE "
+-				   "attribute at %C in a TYPE definition"))
++				  "attribute at %C in a %s definition",
++				   gfc_ascii_comp_state(gfc_current_state())))
+ 		{
+ 		  m = MATCH_ERROR;
+ 		  goto cleanup;
+@@ -3774,8 +4126,8 @@ match_attr_spec (void)
+ 	    }
+ 	  else
+ 	    {
+-	      gfc_error ("Attribute at %L is not allowed in a TYPE definition",
+-			 &seen_at[d]);
++	      gfc_error ("Attribute at %L is not allowed in a %s definition",
++			&seen_at[d], gfc_ascii_comp_state(gfc_current_state()));
+ 	      m = MATCH_ERROR;
+ 	      goto cleanup;
+ 	    }
+@@ -3788,13 +4140,14 @@ match_attr_spec (void)
+ 	    attr = "PRIVATE";
+ 	  else
+ 	    attr = "PUBLIC";
+-	  if (gfc_current_state () == COMP_DERIVED
++	  if (gfc_comp_is_derived (gfc_current_state ())
+ 	      && gfc_state_stack->previous
+ 	      && gfc_state_stack->previous->state == COMP_MODULE)
+ 	    {
+ 	      if (!gfc_notify_std (GFC_STD_F2003, "Attribute %s "
+-				   "at %L in a TYPE definition", attr, 
+-				   &seen_at[d]))
++				   "at %L in a %s definition", attr,
++				   &seen_at[d],
++				   gfc_ascii_comp_state(gfc_current_state())))
+ 		{
+ 		  m = MATCH_ERROR;
+ 		  goto cleanup;
+@@ -3898,6 +4251,10 @@ match_attr_spec (void)
+ 	  t = gfc_add_save (&current_attr, SAVE_EXPLICIT, NULL, &seen_at[d]);
+ 	  break;
+ 
++	case DECL_AUTOMATIC:
++	  t = gfc_add_automatic (&current_attr, NULL, &seen_at[d]);
++	  break;
++
+ 	case DECL_TARGET:
+ 	  t = gfc_add_target (&current_attr, &seen_at[d]);
+ 	  break;
+@@ -3943,6 +4300,7 @@ cleanup:
+   gfc_current_locus = start;
+   gfc_free_array_spec (current_as);
+   current_as = NULL;
++  attr_seen = 0;
+   return m;
+ }
+ 
+@@ -3995,7 +4353,7 @@ set_com_block_bind_c (gfc_common_head *com_block, int is_bind_c)
+ bool
+ gfc_verify_c_interop (gfc_typespec *ts)
+ {
+-  if (ts->type == BT_DERIVED && ts->u.derived != NULL)
++  if (gfc_bt_struct (ts->type) && ts->u.derived != NULL)
+     return (ts->u.derived->ts.is_c_interop || ts->u.derived->attr.is_bind_c)
+ 	   ? true : false;
+   else if (ts->type == BT_CLASS)
+@@ -4087,7 +4445,8 @@ verify_bind_c_sym (gfc_symbol *tmp_sym, gfc_typespec *ts,
+ 	    }
+ 	  else
+ 	    {
+-              if (tmp_sym->ts.type == BT_DERIVED || ts->type == BT_DERIVED)
++              if (gfc_bt_struct (tmp_sym->ts.type)
++                  || gfc_bt_struct (ts->type))
+                 gfc_error ("Type declaration %qs at %L is not C "
+                            "interoperable but it is BIND(C)",
+                            tmp_sym->name, &(tmp_sym->declared_at));
+@@ -4348,7 +4707,7 @@ gfc_match_data_decl (void)
+     return m;
+ 
+   if ((current_ts.type == BT_DERIVED || current_ts.type == BT_CLASS)
+-	&& gfc_current_state () != COMP_DERIVED)
++	&& !gfc_comp_is_derived(gfc_current_state ()))
+     {
+       sym = gfc_use_derived (current_ts.u.derived);
+ 
+@@ -4377,7 +4736,7 @@ gfc_match_data_decl (void)
+       && !current_ts.u.derived->attr.zero_comp)
+     {
+ 
+-      if (current_attr.pointer && gfc_current_state () == COMP_DERIVED)
++      if (current_attr.pointer && gfc_comp_is_derived (gfc_current_state ()))
+ 	goto ok;
+ 
+       gfc_find_symbol (current_ts.u.derived->name,
+@@ -4385,9 +4744,10 @@ gfc_match_data_decl (void)
+ 
+       /* Any symbol that we find had better be a type definition
+ 	 which has its components defined.  */
+-      if (sym != NULL && sym->attr.flavor == FL_DERIVED
++      if (sym != NULL && gfc_fl_struct (sym->attr.flavor)
+ 	  && (current_ts.u.derived->components != NULL
+-	      || current_ts.u.derived->attr.zero_comp))
++	      || current_ts.u.derived->attr.zero_comp
++              || current_ts.u.derived == gfc_new_block))
+ 	goto ok;
+ 
+       gfc_error ("Derived type at %C has not been previously defined "
+@@ -5286,6 +5646,7 @@ gfc_match_procedure (void)
+     case COMP_INTERFACE:
+       m = match_procedure_in_interface ();
+       break;
++    case COMP_STRUCTURE:
+     case COMP_DERIVED:
+       m = match_ppc_decl ();
+       break;
+@@ -5562,6 +5923,10 @@ gfc_match_entry (void)
+ 	    gfc_error ("ENTRY statement at %C cannot appear within "
+ 		       "an INTERFACE");
+ 	    break;
++          case COMP_STRUCTURE:
++            gfc_error ("ENTRY statement at %C cannot appear within "
++                       "a STRUCTURE block");
++            break;
+ 	  case COMP_DERIVED:
+ 	    gfc_error ("ENTRY statement at %C cannot appear within "
+ 		       "a DERIVED TYPE block");
+@@ -6188,6 +6553,24 @@ gfc_match_end (gfc_statement *st)
+       eos_ok = 0;
+       break;
+ 
++    case COMP_MAP:
++      *st = ST_END_MAP;
++      target = " map";
++      eos_ok = 0;
++      break;
++
++    case COMP_UNION:
++      *st = ST_END_UNION;
++      target = " union";
++      eos_ok = 0;
++      break;
++
++    case COMP_STRUCTURE:
++      *st = ST_END_STRUCTURE;
++      target = " structure";
++      eos_ok = 0;
++      break;
++
+     case COMP_DERIVED:
+     case COMP_DERIVED_CONTAINS:
+       *st = ST_END_TYPE;
+@@ -7257,6 +7640,40 @@ syntax:
+   return MATCH_ERROR;
+ }
+ 
++match
++gfc_match_automatic (void)
++{
++  gfc_symbol *sym;
++  match m;
++
++  gfc_match (" ::");
++
++  for (;;)
++    {
++      m = gfc_match_symbol (&sym, 0);
++      switch (m)
++	{
++	case MATCH_YES:
++	  if (!gfc_add_automatic (&sym->attr, sym->name,
++			     &gfc_current_locus))
++	    return MATCH_ERROR;
++	  if (gfc_match_eos () == MATCH_YES)
++	    return MATCH_YES;
++	  if (gfc_match_char (',') != MATCH_YES)
++	    goto syntax;
++	  break;
++	case MATCH_NO:
++	  goto syntax;
++	case MATCH_ERROR:
++	  return MATCH_ERROR;
++	}
++    }
++
++syntax:
++  gfc_error ("Syntax error in AUTOMATIC statement at %C");
++  return MATCH_ERROR;
++}
++
+ 
+ match
+ gfc_match_value (void)
+@@ -7653,6 +8070,216 @@ gfc_get_type_attr_spec (symbol_attribute *attr, char *name)
+   return MATCH_YES;
+ }
+ 
++/* Common function for type declaration blocks similar to derived types, such
++   as STRUCTURES and MAPs. Unlike derived types, a structure type
++   does NOT have a generic symbol matching the name given by the user.
++   STRUCTUREs can share names with variables and PARAMETERs so we must allow
++   for the creation of an independent symbol.
++   Other parameters are a message to prefix errors with, the name of the new 
++   type to be created, and the flavor to add to the resulting symbol. */
++
++static bool
++get_struct_decl (const char *name, sym_flavor fl, locus *decl,
++                 gfc_symbol **result)
++{
++  gfc_symbol *sym;
++  locus where;
++
++  if (decl)
++    where = *decl;
++  else
++    where = gfc_current_locus;
++
++  if (gfc_get_symbol (name, NULL, &sym))
++    return false;
++
++  sym->declared_at = where;
++
++  gcc_assert (name[0] == (char) TOUPPER (name[0]));
++
++  if (sym && (sym->components != NULL || sym->attr.zero_comp))
++  {
++    gfc_error ("Type definition of '%s' at %C was already defined at %L", 
++               sym->name, &sym->declared_at);
++    return false;
++  }
++
++  if (!sym)
++  {
++    gfc_internal_error ("Failed to create structure type '%s' at %C", name);
++    return false;
++  }
++
++  if (sym->attr.flavor != fl
++      && !gfc_add_flavor (&sym->attr, fl, sym->name, NULL))
++    return false;
++
++  if (!sym->hash_value)
++      /* Set the hash for the compound name for this type.  */
++    sym->hash_value = gfc_hash_value (sym);
++
++  /* Normally the type is expected to have been completely parsed by the time
++     a field declaration with this type is seen. For unions, maps, and nested
++     structure declarations, we need to indicate that it is okay that we
++     haven't seen any components yet. This will be updated after the structure
++     is fully parsed. */
++  sym->attr.zero_comp = 0;
++
++  /* Structures always act like derived-types with the SEQUENCE attribute */
++  gfc_add_sequence (&sym->attr, sym->name, NULL);
++
++  if (result) *result = sym;
++
++  return true;
++}
++
++match
++gfc_match_map (void)
++{
++    /* Counter used to give unique internal names to map declarations. */
++    static unsigned int gfc_map_id = 0;
++    char name[GFC_MAX_SYMBOL_LEN + 1];
++    gfc_symbol *sym;
++    locus old_loc;
++
++    old_loc = gfc_current_locus;
++
++    if (gfc_current_state () != COMP_UNION)
++    {
++        gfc_current_locus = old_loc;
++        gfc_error ("MAP statement at %C illegal outside of union declaration");
++        return MATCH_ERROR;
++    }
++    if (gfc_match_eos () != MATCH_YES)
++    {
++        gfc_error ("Expected end of statement at %C after MAP statement");
++        gfc_current_locus = old_loc;
++        return MATCH_ERROR;
++    }
++
++    /* Make up a unique name for the map to store it in the symbol table. */
++    snprintf (name, GFC_MAX_SYMBOL_LEN + 1, "MM$%u", gfc_map_id++);
++
++    if (!get_struct_decl (name, FL_STRUCT, &old_loc, &sym))
++      return MATCH_ERROR;
++
++    gfc_new_block = sym;
++
++    return MATCH_YES;
++}
++
++match
++gfc_match_union (void)
++{
++    /* Counter used to give unique internal names to union declarations. */
++    static unsigned int gfc_union_id = 0;
++    char name[GFC_MAX_SYMBOL_LEN + 1];
++    gfc_symbol *sym;
++    locus old_loc;
++
++    old_loc = gfc_current_locus;
++
++    if (!gfc_comp_is_derived (gfc_current_state ()))
++    {
++        gfc_current_locus = old_loc;
++        gfc_error ("UNION statement at %C illegal outside of structure "
++                   "declaration");
++        return MATCH_ERROR;
++    }
++    if (gfc_match_eos () != MATCH_YES)
++    {
++        gfc_error ("Expected end of statement at %C after UNION statement");
++        gfc_current_locus = old_loc;
++        return MATCH_ERROR;
++    }
++
++    snprintf (name, GFC_MAX_SYMBOL_LEN + 1, "UU$%u", gfc_union_id++);
++    if (!get_struct_decl (name, FL_UNION, &old_loc, &sym))
++      return MATCH_ERROR;
++
++    gfc_new_block = sym;
++
++    return MATCH_YES;
++}
++
++/* Match the beginning of a structure declaration. This is similar to
++   matching the beginning of a derived type declaration, but the resulting
++   symbol has no access control or other interesting attributes. 
++   
++   If we are inside another structure declaration, we expect a field list
++   after the name of the structure. For example, in the following structure,
++   appointments have members START and END which are of ad-hoc structure type.
++   STRUCTURE /APPOINTMENT/ 
++     STRUCTURE /TIME/ START, END
++       INTEGER*1 HOUR, MINUTE, SECOND
++     END STRUCTURE
++     ...
++   END STRUCTURE
++   */
++
++match
++gfc_match_structure_decl (void)
++{
++    /* Counter used to give anonymous structures unique internal names. */
++    static unsigned int gfc_structure_id = 0;
++    char name[GFC_MAX_SYMBOL_LEN + 1];
++    gfc_symbol *sym;
++    match m;
++    locus where;
++
++    if(!gfc_option.flag_dec_structure)
++    {
++        gfc_error ("STRUCTURE at %C is a DEC extension, enable with "
++                   "-fdec-structure");
++        return MATCH_ERROR;
++    }
++
++    name[0] = '\0';
++
++    m = gfc_match (" /%n/", name);
++    if (m != MATCH_YES)
++    {
++        /* Non-nested structure declarations require a structure name. */
++        if (!gfc_comp_is_derived (gfc_current_state ()))
++        {
++            gfc_error ("Structure name expected in non-nested structure "
++                       "declaration at %C");
++            return MATCH_ERROR;
++        }
++        /* This is an anonymous structure; make up a unique name for it
++           (upper-case letters never make it to symbol names from the source).
++           The important thing is initializing the type declaration variable
++           and setting gfc_new_symbol, which is immediately used by
++           parse_structure () and variable_decl () to add fields of this type
++           and add components. */
++        snprintf (name, GFC_MAX_SYMBOL_LEN + 1, "SS$%u", gfc_structure_id++);
++    }
++    where = gfc_current_locus;
++    /* No field list allowed after non-nested structure declaration. */
++    if (!gfc_comp_is_derived (gfc_current_state ()) && gfc_match_eos () != MATCH_YES)
++    {
++        gfc_error ("Field list at %C illegal in non-nested structure "
++                   "declaration");
++        return MATCH_ERROR;
++    }
++
++    /* Make sure the name is not the name of an intrinsic type.  */
++    if (gfc_is_intrinsic_typename (name))
++    {
++      gfc_error ("Structure name '%s' at %C cannot be the same as an intrinsic "
++                 "type", name);
++      return MATCH_ERROR;
++    }
++
++    sprintf (name, gfc_dt_upper_string (name));
++    if (!get_struct_decl (name, FL_STRUCT, &where, &sym))
++      return MATCH_ERROR;
++
++    gfc_new_block = sym;
++    return MATCH_YES;
++}
++
++
+ 
+ /* Match the beginning of a derived type declaration.  If a type name
+    was the result of a function, then it is possible to have a symbol
+@@ -7669,9 +8296,10 @@ gfc_match_derived_decl (void)
+   match m;
+   match is_type_attr_spec = MATCH_NO;
+   bool seen_attr = false;
++  locus where;
+   gfc_interface *intr = NULL, *head;
+ 
+-  if (gfc_current_state () == COMP_DERIVED)
++  if (gfc_comp_is_derived (gfc_current_state ()))
+     return MATCH_NO;
+ 
+   name[0] = '\0';
+@@ -7703,7 +8331,11 @@ gfc_match_derived_decl (void)
+       return MATCH_ERROR;
+     }
+ 
+-  m = gfc_match (" %n%t", name);
++  m = gfc_match (" %n", name);
++  if (m != MATCH_YES)
++    return m;
++  where = gfc_current_locus;
++  m = gfc_match_eos ();
+   if (m != MATCH_YES)
+     return m;
+ 
+@@ -7757,6 +8389,7 @@ gfc_match_derived_decl (void)
+       intr->next = head;
+       gensym->generic = intr;
+       gensym->attr.if_source = IFSRC_DECL;
++      gensym->declared_at = where;
+     }
+ 
+   /* The symbol may already have the derived attribute without the
+@@ -7800,7 +8433,7 @@ gfc_match_derived_decl (void)
+ 
+       p->ts.type = BT_DERIVED;
+       p->ts.u.derived = extended;
+-      p->initializer = gfc_default_initializer (&p->ts);
++      p->initializer = gfc_default_initializer (&p->ts, false);
+ 
+       /* Set extension level.  */
+       if (extended->attr.extension == 255)
+@@ -7825,6 +8458,13 @@ gfc_match_derived_decl (void)
+   /* Take over the ABSTRACT attribute.  */
+   sym->attr.abstract = attr.abstract;
+ 
++  /* Normally the type is expected to have been completely parsed by the time
++     a field declaration with this type is seen. For unions, maps, and nested
++     structure declarations, we need to indicate that it is okay that we
++     haven't seen any components yet. This will be updated after the structure
++     is fully parsed. */
++  sym->attr.zero_comp = sym->components == NULL;
++
+   gfc_new_block = sym;
+ 
+   return MATCH_YES;
+diff --git a/gcc/fortran/dependency.c b/gcc/fortran/dependency.c
+index 63c6630..5aef9fd 100644
+--- a/gcc/fortran/dependency.c
++++ b/gcc/fortran/dependency.c
+@@ -2153,7 +2153,7 @@ gfc_dep_resolver (gfc_ref *lref, gfc_ref *rref, gfc_reverse *reverse)
+ 
+ 	      /* Now deal with the loop reversal logic:  This only works on
+ 		 ranges and is activated by setting
+-				reverse[n] == GFC_ENABLE_REVERSE
++				reverse[m] == GFC_ENABLE_REVERSE
+ 		 The ability to reverse or not is set by previous conditions
+ 		 in this dimension.  If reversal is not activated, the
+ 		 value GFC_DEP_BACKWARD is reset to GFC_DEP_OVERLAP.  */
+diff --git a/gcc/fortran/dump-parse-tree.c b/gcc/fortran/dump-parse-tree.c
+index 83ecbaa..7c22e3b 100644
+--- a/gcc/fortran/dump-parse-tree.c
++++ b/gcc/fortran/dump-parse-tree.c
+@@ -109,6 +109,10 @@ show_typespec (gfc_typespec *ts)
+       fprintf (dumpfile, "%s", ts->u.derived->name);
+       break;
+ 
++    case BT_UNION:
++      fprintf (dumpfile, "%s", ts->u.derived->name);
++      break;
++
+     case BT_CHARACTER:
+       if (ts->u.cl)
+ 	show_expr (ts->u.cl->length);
+diff --git a/gcc/fortran/expr.c b/gcc/fortran/expr.c
+index cc382d3..2d0bc67 100644
+--- a/gcc/fortran/expr.c
++++ b/gcc/fortran/expr.c
+@@ -335,9 +335,9 @@ gfc_copy_expr (gfc_expr *p)
+ 
+ 	case BT_HOLLERITH:
+ 	case BT_LOGICAL:
+-	case BT_DERIVED:
+ 	case BT_CLASS:
+ 	case BT_ASSUMED:
++        case_struct_bt:
+ 	  break;		/* Already done.  */
+ 
+ 	case BT_PROCEDURE:
+@@ -1279,7 +1279,7 @@ find_component_ref (gfc_constructor_base base, gfc_ref *ref)
+   /* For extended types, check if the desired component is in one of the
+    * parent types.  */
+   while (ext > 0 && gfc_find_component (dt->components->ts.u.derived,
+-					pick->name, true, true))
++					pick->name, true, true, NULL))
+     {
+       dt = dt->components->ts.u.derived;
+       c = gfc_constructor_first (c->expr->value.constructor);
+@@ -1649,7 +1649,8 @@ simplify_const_ref (gfc_expr *p)
+ 
+ 	    case AR_FULL:
+ 	      if (p->ref->next != NULL
+-		  && (p->ts.type == BT_CHARACTER || p->ts.type == BT_DERIVED))
++		  && (p->ts.type == BT_CHARACTER 
++                      || gfc_bt_struct (p->ts.type)))
+ 		{
+ 		  for (c = gfc_constructor_first (p->value.constructor);
+ 		       c; c = gfc_constructor_next (c))
+@@ -1659,7 +1660,7 @@ simplify_const_ref (gfc_expr *p)
+ 			return false;
+ 		    }
+ 
+-		  if (p->ts.type == BT_DERIVED
++		  if (gfc_bt_struct (p->ts.type)
+ 			&& p->ref->next
+ 			&& (c = gfc_constructor_first (p->value.constructor)))
+ 		    {
+@@ -2708,6 +2709,58 @@ gfc_match_init_expr (gfc_expr **result)
+   return MATCH_YES;
+ }
+ 
++/* Apply an initialization expression to a typespec.
++   Can be used for both symbols and components.
++   Similar to add_init_expr_to_sym in decl.c; could probably be combined with
++   some effort. */
++void
++gfc_apply_init (gfc_typespec *ts, symbol_attribute *attr, gfc_expr *init)
++{
++  if (ts->type == BT_CHARACTER && !attr->pointer && init
++      && ts->u.cl
++      && ts->u.cl->length && ts->u.cl->length->expr_type == EXPR_CONSTANT)
++    {
++      int len;
++
++      gcc_assert (ts->u.cl && ts->u.cl->length);
++      gcc_assert (ts->u.cl->length->expr_type == EXPR_CONSTANT);
++      gcc_assert (ts->u.cl->length->ts.type == BT_INTEGER);
++
++      len = mpz_get_si (ts->u.cl->length->value.integer);
++
++      if (init->expr_type == EXPR_CONSTANT)
++	gfc_set_constant_character_len (len, init, -1);
++      else if (mpz_cmp (ts->u.cl->length->value.integer,
++			init->ts.u.cl->length->value.integer))
++	{
++	  gfc_constructor *ctor;
++	  ctor = gfc_constructor_first (init->value.constructor);
++
++	  if (ctor)
++	    {
++	      int first_len;
++	      bool has_ts = (init->ts.u.cl
++			     && init->ts.u.cl->length_from_typespec);
++
++	      /* Remember the length of the first element for checking
++		 that all elements *in the constructor* have the same
++		 length.  This need not be the length of the LHS!  */
++	      gcc_assert (ctor->expr->expr_type == EXPR_CONSTANT);
++	      gcc_assert (ctor->expr->ts.type == BT_CHARACTER);
++	      first_len = ctor->expr->value.character.length;
++
++	      for ( ; ctor; ctor = gfc_constructor_next (ctor))
++		if (ctor->expr->expr_type == EXPR_CONSTANT)
++		{
++		  gfc_set_constant_character_len (len, ctor->expr,
++						  has_ts ? -1 : first_len);
++		  ctor->expr->ts.u.cl->length = gfc_copy_expr (ts->u.cl->length);
++		}
++	    }
++	}
++    }
++}
++
+ 
+ /* Given an actual argument list, test to see that each argument is a
+    restricted expression and optionally if the expression type is
+@@ -3298,6 +3351,9 @@ gfc_check_assign (gfc_expr *lvalue, gfc_expr *rvalue, int conform)
+ 	  || rvalue->ts.type == BT_HOLLERITH)
+ 	return true;
+ 
++      if (gfc_option.allow_std & GFC_STD_EXTRA_LEGACY && gfc_numeric_ts (&lvalue->ts) && rvalue->ts.type == BT_CHARACTER)
++	return true;
++
+       if (lvalue->ts.type == BT_LOGICAL && rvalue->ts.type == BT_LOGICAL)
+ 	return true;
+ 
+@@ -3920,9 +3976,10 @@ gfc_has_default_initializer (gfc_symbol *der)
+ {
+   gfc_component *c;
+ 
+-  gcc_assert (der->attr.flavor == FL_DERIVED);
++  gcc_assert (gfc_fl_struct (der->attr.flavor));
+   for (c = der->components; c; c = c->next)
+-    if (c->ts.type == BT_DERIVED)
++  {
++    if (gfc_bt_struct (c->ts.type))
+       {
+         if (!c->attr.pointer
+ 	     && gfc_has_default_initializer (c->ts.u.derived))
+@@ -3935,26 +3992,124 @@ gfc_has_default_initializer (gfc_symbol *der)
+         if (c->initializer)
+ 	  return true;
+       }
++  }
+ 
+   return false;
+ }
+ 
+ 
+-/* Get an expression for a default initializer.  */
++/* Only the last initializer in a union matters. */
++static gfc_expr *
++get_last_init (gfc_symbol *uniont, gfc_component **mapp)
++{
++  gfc_component *map;
++  gfc_expr *init=NULL, *init2;
++  for (map = uniont->components; map; map = map->next)
++  {
++    if (!gfc_has_default_initializer (map->ts.u.derived))
++      continue;
++
++    init2 = gfc_default_initializer (&map->ts, false);
++    if (!init2)
++      continue;
++
++    if (init)
++    {
++      gfc_warning_now (0, "Initializer in map at %L overwritten by initializer in "
++                       "map at %L in union", &init->where, &init2->where);
++      gfc_free_expr (init);
++    }
++
++    init = init2;
++    if (mapp) *mapp = map;
++  }
++  if (!init) *mapp = NULL;
++  return init;
++}
++
++
++/* Fetch or generate an initializer for the given component.
++   Only generate an initializer if generate is true. */
++
++static gfc_expr *
++component_init (gfc_component *c, bool generate)
++{
++  gfc_component *map = NULL;
++  gfc_expr *init = NULL;
++
++  if (c->initializer) return c->initializer;
++
++  /* Recursively handle derived type components */
++  if (generate && (c->ts.type == BT_DERIVED || c->ts.type == BT_CLASS))
++    init = gfc_default_initializer (&c->ts, true);
++
++  else if (c->ts.type == BT_UNION && c->ts.u.derived->components)
++  {
++    /* TODO: keep _all_ map initializers here, and squash them together
++       during the translation phase (in trans-expr.c:gfc_conv_structure?)
++       to allow non-overlapping initializers across maps. */
++
++    /* Try to take an existing initializer from a map. */
++    gfc_constructor *ctor;
++    init = get_last_init (c->ts.u.derived, &map);
++
++    if (!map)
++    {
++      gcc_assert (init == NULL);
++      /* If no maps had an explicit initializer, and generate is not set, then
++         this union has no initializer. Otherwise generate an initializer from
++         the first map. */
++      /* TODO: Use the largest map / initialize the entire union.
++         This can only be determined in translation (?) */
++      if (!generate)
++        return NULL;
++      map = c->ts.u.derived->components;
++      init = gfc_default_initializer (&map->ts, true);
++    }
++
++    ctor = gfc_constructor_get ();
++    ctor->expr = init;
++    ctor->n.component = map;
++
++    init = gfc_get_structure_constructor_expr (c->ts.type, c->ts.kind, &c->loc);
++    init->ts = c->ts;
++    gfc_constructor_append (&init->value.constructor, ctor);
++  }
++
++  /* Simple components */
++  else if (generate)
++  {
++    init = gfc_build_default_init_expr (&c->ts, &c->loc);
++    gfc_apply_init (&c->ts, &c->attr, init);
++  }
++
++  return init;
++}
++
++
++/* Get an expression for a default initializer of a derived type. 
++   If -finit-derived is specified, generate default initialization expressions
++   for components that lack them as with gfc_build_default_init_expr. */
+ 
+ gfc_expr *
+-gfc_default_initializer (gfc_typespec *ts)
++gfc_default_initializer (gfc_typespec *ts, bool generate)
+ {
+-  gfc_expr *init;
++  gfc_expr *init, *tmp;
+   gfc_component *comp;
++  generate = gfc_option.flag_init_derived && generate;
+ 
+   /* See if we have a default initializer in this, but not in nested
+-     types (otherwise we could use gfc_has_default_initializer()).  */
+-  for (comp = ts->u.derived->components; comp; comp = comp->next)
+-    if (comp->initializer || comp->attr.allocatable
+-	|| (comp->ts.type == BT_CLASS && CLASS_DATA (comp)
+-	    && CLASS_DATA (comp)->attr.allocatable))
+-      break;
++     types (otherwise we could use gfc_has_default_initializer()).
++     We don't need to check if we are going to generate them. */
++  comp = ts->u.derived->components;
++  if (!generate)
++  {
++    for (; comp; comp = comp->next)
++      if (comp->initializer || comp->attr.allocatable
++          || (comp->ts.type == BT_CLASS && CLASS_DATA (comp)
++              && CLASS_DATA (comp)->attr.allocatable))
++        break;
++  }
+ 
+   if (!comp)
+     return NULL;
+diff --git a/gcc/fortran/gfortran.h b/gcc/fortran/gfortran.h
+index 9d09de6..d9be90e 100644
+--- a/gcc/fortran/gfortran.h
++++ b/gcc/fortran/gfortran.h
+@@ -64,6 +64,16 @@ not after.
+ 
+ #define gfc_is_whitespace(c) ((c==' ') || (c=='\t'))
+ 
++/* Common macros to check structure-like types and flavors, since things like
++   STRUCTURES, MAPs and UNIONs are often treated similarly. */
++
++#define gfc_bt_struct(t) \
++  ((t) == BT_DERIVED || (t) == BT_UNION)
++#define gfc_fl_struct(f) \
++  ((f) == FL_DERIVED || (f) == FL_UNION || (f) == FL_STRUCT)
++#define case_struct_bt case BT_DERIVED: case BT_UNION
++#define case_struct_fl case FL_DERIVED: case FL_UNION: case FL_STRUCT
++
+ /* Stringization.  */
+ #define stringize(x) expand_macro(x)
+ #define expand_macro(x) # x
+@@ -207,6 +217,7 @@ typedef enum
+   ST_END_FILE, ST_FINAL, ST_FLUSH, ST_END_FORALL, ST_END_FUNCTION, ST_ENDIF,
+   ST_END_INTERFACE, ST_END_MODULE, ST_END_PROGRAM, ST_END_SELECT,
+   ST_END_SUBROUTINE, ST_END_WHERE, ST_END_TYPE, ST_ENTRY, ST_EQUIVALENCE,
++  ST_END_STRUCTURE,
+   ST_ERROR_STOP, ST_EXIT, ST_FORALL, ST_FORALL_BLOCK, ST_FORMAT, ST_FUNCTION,
+   ST_GOTO, ST_IF_BLOCK, ST_IMPLICIT, ST_IMPLICIT_NONE, ST_IMPORT,
+   ST_INQUIRE, ST_INTERFACE, ST_SYNC_ALL, ST_SYNC_MEMORY, ST_SYNC_IMAGES,
+@@ -215,6 +226,7 @@ typedef enum
+   ST_STOP, ST_SUBROUTINE, ST_TYPE, ST_USE, ST_WHERE_BLOCK, ST_WHERE, ST_WAIT,
+   ST_WRITE, ST_ASSIGNMENT, ST_POINTER_ASSIGNMENT, ST_SELECT_CASE, ST_SEQUENCE,
+   ST_SIMPLE_IF, ST_STATEMENT_FUNCTION, ST_DERIVED_DECL, ST_LABEL_ASSIGNMENT,
++  ST_STRUCTURE_DECL, ST_UNION, ST_END_UNION, ST_MAP, ST_END_MAP,
+   ST_ENUM, ST_ENUMERATOR, ST_END_ENUM, ST_SELECT_TYPE, ST_TYPE_IS, ST_CLASS_IS,
+   ST_OACC_PARALLEL_LOOP, ST_OACC_END_PARALLEL_LOOP, ST_OACC_PARALLEL,
+   ST_OACC_END_PARALLEL, ST_OACC_KERNELS, ST_OACC_END_KERNELS, ST_OACC_DATA,
+@@ -267,12 +279,12 @@ typedef enum
+ interface_type;
+ 
+ /* Symbol flavors: these are all mutually exclusive.
+-   10 elements = 4 bits.  */
++   12 elements = 4 bits.  */
+ typedef enum sym_flavor
+ {
+   FL_UNKNOWN = 0, FL_PROGRAM, FL_BLOCK_DATA, FL_MODULE, FL_VARIABLE,
+   FL_PARAMETER, FL_LABEL, FL_PROCEDURE, FL_DERIVED, FL_NAMELIST,
+-  FL_VOID
++  FL_UNION, FL_STRUCT, FL_VOID
+ }
+ sym_flavor;
+ 
+@@ -636,6 +648,8 @@ typedef enum
+ }
+ gfc_reverse;
+ 
++enum match_type { MATCH_EXACT, MATCH_PROMOTABLE, MATCH_INVALID };
++
+ /************************* Structures *****************************/
+ 
+ /* Used for keeping things in balanced binary trees.  */
+@@ -740,7 +754,7 @@ typedef struct
+     optional:1, pointer:1, target:1, value:1, volatile_:1, temporary:1,
+     dummy:1, result:1, assign:1, threadprivate:1, not_always_present:1,
+     implied_index:1, subref_array_pointer:1, proc_pointer:1, asynchronous:1,
+-    contiguous:1, fe_temp: 1;
++    contiguous:1, fe_temp: 1, automatic:1;
+ 
+   /* For CLASS containers, the pointer attribute is sometimes set internally
+      even though it was not directly specified.  In this case, keep the
+@@ -974,7 +988,7 @@ typedef struct
+ 
+   union
+   {
+-    struct gfc_symbol *derived;	/* For derived types only.  */
++    struct gfc_symbol *derived;	/* For derived types or unions.  */
+     gfc_charlen *cl;		/* For character types only.  */
+     int pad;			/* For hollerith types only.  */
+   }
+@@ -1028,6 +1042,9 @@ typedef struct gfc_component
+ 
+   /* Needed for procedure pointer components.  */
+   struct gfc_typebound_proc *tb;
++
++  /* Pointer to MAP list for union types. */
++  struct gfc_symbol *maps;
+ }
+ gfc_component;
+ 
+@@ -2478,6 +2495,10 @@ typedef struct
+   int flag_init_logical;
+   int flag_init_character;
+   char flag_init_character_value;
++  int flag_dec_structure;
++  int flag_init_derived;
++  int flag_dec_member_dot;
++  int flag_loc_rval;
+ 
+   int fpe;
+   int fpe_summary;
+@@ -2703,6 +2724,7 @@ bool gfc_check_any_c_kind (gfc_typespec *);
+ int gfc_validate_kind (bt, int, bool);
+ int gfc_get_int_kind_from_width_isofortranenv (int size);
+ int gfc_get_real_kind_from_width_isofortranenv (int size);
++tree gfc_get_union_type (gfc_symbol *);
+ tree gfc_get_derived_type (gfc_symbol * derived);
+ extern int gfc_index_integer_kind;
+ extern int gfc_default_integer_kind;
+@@ -2779,6 +2801,8 @@ bool gfc_add_flavor (symbol_attribute *, sym_flavor, const char *, locus *);
+ bool gfc_add_entry (symbol_attribute *, const char *, locus *);
+ bool gfc_add_procedure (symbol_attribute *, procedure_type,
+ 		       const char *, locus *);
++bool gfc_add_automatic (symbol_attribute *, const char *, locus *);
++
+ bool gfc_add_intent (symbol_attribute *, sym_intent, locus *);
+ bool gfc_add_explicit_interface (gfc_symbol *, ifsrc,
+ 				gfc_formal_arglist *, locus *);
+@@ -2791,7 +2815,8 @@ bool gfc_copy_attr (symbol_attribute *, symbol_attribute *, locus *);
+ bool gfc_add_component (gfc_symbol *, const char *, gfc_component **);
+ gfc_symbol *gfc_use_derived (gfc_symbol *);
+ gfc_symtree *gfc_use_derived_tree (gfc_symtree *);
+-gfc_component *gfc_find_component (gfc_symbol *, const char *, bool, bool);
++gfc_component *gfc_find_component (gfc_symbol *, const char *, bool, bool,
++                                   gfc_ref **);
+ 
+ gfc_st_label *gfc_get_st_label (int);
+ void gfc_free_st_label (gfc_st_label *);
+@@ -2987,7 +3012,9 @@ bool gfc_check_pointer_assign (gfc_expr *, gfc_expr *);
+ bool gfc_check_assign_symbol (gfc_symbol *, gfc_component *, gfc_expr *);
+ 
+ bool gfc_has_default_initializer (gfc_symbol *);
+-gfc_expr *gfc_default_initializer (gfc_typespec *);
++gfc_expr *gfc_default_initializer (gfc_typespec *, bool);
++gfc_expr *gfc_build_default_init_expr (gfc_typespec *, locus *);
++void gfc_apply_init (gfc_typespec *, symbol_attribute *, gfc_expr *);
+ gfc_expr *gfc_get_variable_expr (gfc_symtree *);
+ void gfc_add_full_array_ref (gfc_expr *, gfc_array_spec *);
+ gfc_expr * gfc_lval_expr_from_sym (gfc_symbol *);
+@@ -3086,6 +3113,7 @@ bool gfc_ref_dimen_size (gfc_array_ref *, int dimen, mpz_t *, mpz_t *);
+ 
+ /* interface.c -- FIXME: some of these should be in symbol.c */
+ void gfc_free_interface (gfc_interface *);
++int gfc_compare_union_types (gfc_symbol *, gfc_symbol *);
+ int gfc_compare_derived_types (gfc_symbol *, gfc_symbol *);
+ int gfc_compare_types (gfc_typespec *, gfc_typespec *);
+ int gfc_compare_interfaces (gfc_symbol*, gfc_symbol*, const char *, int, int,
+@@ -3103,7 +3131,7 @@ bool gfc_add_interface (gfc_symbol *);
+ gfc_interface *gfc_current_interface_head (void);
+ void gfc_set_current_interface_head (gfc_interface *);
+ gfc_symtree* gfc_find_sym_in_symtree (gfc_symbol*);
+-bool gfc_arglist_matches_symbol (gfc_actual_arglist**, gfc_symbol*);
++bool gfc_arglist_matches_symbol (gfc_actual_arglist**, gfc_symbol*, enum match_type mtype);
+ bool gfc_check_operator_interface (gfc_symbol*, gfc_intrinsic_op, locus);
+ int gfc_has_vector_subscript (gfc_expr*);
+ gfc_intrinsic_op gfc_equivalent_op (gfc_intrinsic_op);
+@@ -3131,6 +3159,8 @@ void gfc_module_done_2 (void);
+ void gfc_dump_module (const char *, int);
+ bool gfc_check_symbol_access (gfc_symbol *);
+ void gfc_free_use_stmts (gfc_use_list *);
++const char *gfc_dt_lower_string (const char *);
++const char *gfc_dt_upper_string (const char *);
+ 
+ /* primary.c */
+ symbol_attribute gfc_variable_attr (gfc_expr *, gfc_typespec *);
+diff --git a/gcc/fortran/gfortran.texi b/gcc/fortran/gfortran.texi
+index a06c5fc..580ac75 100644
+--- a/gcc/fortran/gfortran.texi
++++ b/gcc/fortran/gfortran.texi
+@@ -1368,7 +1368,6 @@ extensions.
+ * Extensions not implemented in GNU Fortran::
+ @end menu
+ 
+-
+ @node Extensions implemented in GNU Fortran
+ @section Extensions implemented in GNU Fortran
+ @cindex extensions, implemented
+@@ -1405,6 +1404,8 @@ without warning.
+ * OpenACC::
+ * Argument list functions::
+ * Read/Write after EOF marker::
++* AUTOMATIC statement::
++* Optional DEC extension support::
+ @end menu
+ 
+ @node Old-style kind specifications
+@@ -2044,6 +2045,9 @@ C
+       end
+ @end smallexample
+ 
++Use of @code{%LOC()} as an rvalue is supported with the flag
++@option{-floc-rval} (its behavior is identical to the @code{LOC()} intrinsic).
++
+ For details refer to the g77 manual
+ @uref{https://gcc.gnu.org/@/onlinedocs/@/gcc-3.4.6/@/g77/@/index.html#Top}.
+ 
+@@ -2063,49 +2067,59 @@ consider @code{BACKSPACE} or @code{REWIND} to properly position
+ the file before the EOF marker.  As an extension, the run-time error may
+ be disabled using -std=legacy.
+ 
+-@node Extensions not implemented in GNU Fortran
+-@section Extensions not implemented in GNU Fortran
+-@cindex extensions, not implemented
++@node AUTOMATIC statement
++@subsection AUTOMATIC statement
++@cindex AUTOMATIC statement
+ 
+-The long history of the Fortran language, its wide use and broad
+-userbase, the large number of different compiler vendors and the lack of
+-some features crucial to users in the first standards have lead to the
+-existence of a number of important extensions to the language.  While
+-some of the most useful or popular extensions are supported by the GNU
+-Fortran compiler, not all existing extensions are supported.  This section
+-aims at listing these extensions and offering advice on how best make
+-code that uses them running with the GNU Fortran compiler.
++AUTOMATIC is the opposite to the standard SAVE statement. While SAVE forces
++variables to be placed in non-stack memory where it won't be overwritten,
++AUTOMATIC forces all variable declared with it to be on the stack.
++
++AUTOMATIC overrides -fno-automatic.
++
++@node Optional DEC extension support
++@subsection Optional DEC extension support
++@cindex extensions, dec
++
++Long long ago in a land far far away, in the time before Fortran standards
++existed, compiler writers loved to add extensions to Fortran for anyone who
++asked them nicely. The most popular of these extensions were implemented by
++Digital Equipment Corporation (DEC). Since they were so popular they were
++maintained in the Digital (and since Intel) compiler long after standards were
++introduced. Unfortunately these extensions remain in use by a number of users.
+ 
+ @c More can be found here:
+ @c   -- https://gcc.gnu.org/onlinedocs/gcc-3.4.6/g77/Missing-Features.html
+ @c   -- the list of Fortran and libgfortran bugs closed as WONTFIX:
+ @c      http://tinyurl.com/2u4h5y
+ 
++GNU Fortran provides selective automatic support for some of these
++extensions, described in the previous section @ref{Extensions implemented in
++GNU Fortran}. Other DEC extensions are so heinous that GNU Fortran requires the
++user to explicitly enable them; these are the "optional" DEC extensions,
++described here.
++
+ @menu
+ * STRUCTURE and RECORD::
+-@c * UNION and MAP::
+-* ENCODE and DECODE statements::
+-* Variable FORMAT expressions::
++* UNION and MAP::
+ @c * Q edit descriptor::
+ @c * AUTOMATIC statement::
+ @c * TYPE and ACCEPT I/O Statements::
+ @c * .XOR. operator::
+ @c * CARRIAGECONTROL, DEFAULTFILE, DISPOSE and RECORDTYPE I/O specifiers::
+ @c * Omitted arguments in procedure call::
+-* Alternate complex function syntax::
+-* Volatile COMMON blocks::
+ @end menu
+ 
+-
+ @node STRUCTURE and RECORD
+-@subsection @code{STRUCTURE} and @code{RECORD}
++@subsubsection @code{STRUCTURE} and @code{RECORD}
+ @cindex @code{STRUCTURE}
+ @cindex @code{RECORD}
+ 
+-Record structures are a pre-Fortran-90 vendor extension to create
+-user-defined aggregate data types.  GNU Fortran does not support
+-record structures, only Fortran 90's ``derived types'', which have
+-a different syntax.
++Record structures are a pre-Fortran-90 DEC extension to create
++user-defined aggregate data types. Support for record structures in GNU
++Fortran can be enabled with the @option{-fdec-structure} compile option.
++If you have a choice, you should instead use Fortran 90's ``derived types'',
++which have a different syntax. 
+ 
+ In many cases, record structures can easily be converted to derived types.
+ To convert, replace @code{STRUCTURE /}@var{structure-name}@code{/}
+@@ -2114,6 +2128,10 @@ by @code{TYPE} @var{type-name}.  Additionally, replace
+ @code{TYPE(}@var{type-name}@code{)}. Finally, in the component access,
+ replace the period (@code{.}) by the percent sign (@code{%}).
+ 
++Note that component access by period can be enabled for derived types
++separately from structure/record support with @option{-fdec-member-dot};
++however, it is enabled automatically with @option{-fdec-structure}.
++
+ Here is an example of code using the non portable record structure syntax:
+ 
+ @example
+@@ -2171,16 +2189,197 @@ store_catalog(12) = pear
+ print *, store_catalog(12)
+ @end example
+ 
++@noindent
++Structures and derived types differ in a few ways:
++
++@itemize @bullet
++@item Structures act like derived types with the @code{SEQUENCE} attribute.
++Otherwise they may contain no specifiers.
++
++@item Structures may contain a variable with the name @code{%FILL}; this will
++create an anonymous component which cannot be referenced but fills space just
++like a component for alignment purposes. For example, the following structure
++will take up sixteen bytes:
++
++@smallexample 
++structure /useless/
++  integer(4) i
++  integer(8) %FILL
++end structure
++@end smallexample
++
++@item Structures may share names with other symbols. For example, the following
++is invalid for derived types, but valid for structures:
++
++@smallexample
++structure /Header/
++  ! ...
++end structure
++record /Header/ header
++@end smallexample
++
++@item Structures may be defined 'ad-hoc' within another parent structure. The
++type names for these structures may be ommitted, in which case the structure
++type itself is anonymous, and other structures of the same type cannot be
++instantiated. The following shows some examples:
++
++@example
++type appointment
++  ! 'ad-hoc' structure definition; app_time is an array of two 'time'
++  structure /time/ app_time (2) 
++    integer(1) hour, minute
++  end structure
++  character(10) memo
++end type appointment
++
++! The 'time' structure is still usable
++record /time/ now
++now = time(5, 30)
++
++...
++
++type appointment
++  ! anonymous ad-hoc structure definition
++  structure start, end
++    integer(1) hour, minute
++  end structure
++  character(10) memo
++end type appointment
++@end example
++
++@item Structures may contain @code{UNION} declarations. For more detail see the
++section on @ref{UNION and MAP}.
++
++@item Structures support old-style initialization of components, identical to
++those described in @ref{Old-style variable initialization}.
++@end itemize
++
++@node UNION and MAP
++@subsubsection @code{UNION} and @code{MAP}
++@cindex @code{UNION}
++@cindex @code{MAP}
++
++Unions are a DEC extension which were commonly used with the non-standard
++@ref{STRUCTURE and RECORD} extensions. Use of @code{UNION} and @code{MAP} is
++automatically enabled with @option{-fdec-structure}.
++
++A @code{UNION} declaration occurs within a structure; within the definition of
++each union is a number of @code{MAP} definitions. Each @code{MAP} shares
++storage with its sibling maps (in the same union), and the size of the union
++is the size of the largest map within it, just as with unions in C. The major
++difference is that component references do not indicate which union or map the
++component is in (the compiler gets to figure that out).
++
++Here is a small example:
++@smallexample
++structure /words_long/
++union
++  map
++    integer(2) w0, w1, w2
++  end map
++  map
++    integer(4) long
++  end map
++end union
++end structure
++@end smallexample
++
++The two maps share memory, and the size of the union is ultimately six bytes:
++
++@example
++0    1    2    3    4   5   6     Byte offset
++-------------------------------
++|    |    |    |    |    |    |
++-------------------------------
++
++^    W0   ^    W1   ^    W2   ^
++ \-------/ \-------/ \-------/
++
++^       LONG        ^  unused ^
++ \-----------------/ \-------/
++@end example
++
++Following is an example mirroring the layout of an Intel x86_64 register:
++
++@example
++structure /reg/
++  union    ! rax
++    map
++      integer*8 rx         ! rax
++    end map
++    map
++      integer*4 rh         ! rah
++      union   ! eax
++        map
++          integer*4 rl     ! ral
++        end map
++        map
++          integer*4 ex     ! eax
++        end map
++        map
++          integer*2 eh     ! eah
++          union     ! ax
++            map
++              integer*2 el ! eal
++            end map
++            map
++              integer*2 x  ! ax
++            end map
++            map
++              integer*1 h  ! ah
++              integer*1 l  ! al
++            end map
++          end union ! ax
++        end map
++      end union ! eax
++    end map
++  end union ! rax
++end structure
++
++record /reg/ a
++
++! After this assignment...
++a.rx = z'AABBCCCCFFFFFFFF'
++
++! The following is true:
++!
++! a.rx == z'AABBCCCCFFFFFFFF'
++! a.rh ==         z'FFFFFFFF'
++! a.rl == z'AABBCCCC'
++!
++! a.ex == z'AABBCCCC'
++! a.eh ==     z'CCCC'
++! a.el == z'AABB'
++!
++!  a.x == z'AABB'
++!  a.h ==   z'BB'
++!  a.l == z'AA'
++@end example
++
++@node Extensions not implemented in GNU Fortran
++@section Extensions not implemented in GNU Fortran
++@cindex extensions, not implemented
++
++The long history of the Fortran language, its wide use and broad
++userbase, the large number of different compiler vendors and the lack of
++some features crucial to users in the first standards have lead to the
++existence of a number of important extensions to the language.  While
++some of the most useful or popular extensions are supported by the GNU
++Fortran compiler, not all existing extensions are supported.  This section
++aims at listing these extensions and offering advice on how best make
++code that uses them running with the GNU Fortran compiler.
+ 
+-@c @node UNION and MAP
+-@c @subsection @code{UNION} and @code{MAP}
+-@c @cindex @code{UNION}
+-@c @cindex @code{MAP}
+-@c
+-@c For help writing this one, see
+-@c http://www.eng.umd.edu/~nsw/ench250/fortran1.htm#UNION and
+-@c http://www.tacc.utexas.edu/services/userguides/pgi/pgiws_ug/pgi32u06.htm
++@c More can be found here:
++@c   -- http://gcc.gnu.org/onlinedocs/gcc-3.4.6/g77/Missing-Features.html
++@c   -- the list of Fortran and libgfortran bugs closed as WONTFIX:
++@c      http://tinyurl.com/2u4h5y
+ 
++@menu
++* ENCODE and DECODE statements::
++* Variable FORMAT expressions::
++* Alternate complex function syntax::
++* Volatile COMMON blocks::
++@end menu
+ 
+ @node ENCODE and DECODE statements
+ @subsection @code{ENCODE} and @code{DECODE} statements
+@@ -2287,7 +2486,6 @@ well as @code{COMPLEX*16 FUNCTION name()}.  Both are non-standard, legacy
+ extensions.  @command{gfortran} accepts the latter form, which is more
+ common, but not the former.
+ 
+-
+ @node Volatile COMMON blocks
+ @subsection Volatile @code{COMMON} blocks
+ @cindex @code{VOLATILE}
+@@ -2300,7 +2498,6 @@ invalid standard Fortran syntax and is not supported by
+ @code{VOLATILE} variables in @code{COMMON} blocks since revision 4.3.
+ 
+ 
+-
+ @c ---------------------------------------------------------------------
+ @c Mixed-Language Programming
+ @c ---------------------------------------------------------------------
+@@ -2322,7 +2519,6 @@ if one links Fortran code compiled by different compilers.  In most cases,
+ use of the C Binding features of the Fortran 2003 standard is sufficient,
+ and their use is highly recommended.
+ 
+-
+ @node Interoperability with C
+ @section Interoperability with C
+ 
+diff --git a/gcc/fortran/interface.c b/gcc/fortran/interface.c
+index 745dd30..1eedd88 100644
+--- a/gcc/fortran/interface.c
++++ b/gcc/fortran/interface.c
+@@ -387,19 +387,142 @@ gfc_match_end_interface (void)
+ }
+ 
+ 
++static int
++compare_components (gfc_component *cmp1, gfc_component *cmp2,
++    gfc_symbol *derived1, gfc_symbol *derived2)
++{
++  gfc_symbol *d1, *d2;
++  bool anonymous = false;
++
++  d1 = cmp1->ts.u.derived;
++  d2 = cmp2->ts.u.derived;
++  if (   (d1 && (d1->attr.flavor == FL_STRUCT || d1->attr.flavor == FL_UNION)
++          && ISUPPER (cmp1->name[1]))
++      || (d2 && (d2->attr.flavor == FL_STRUCT || d2->attr.flavor == FL_UNION)
++          && ISUPPER (cmp1->name[1])))
++    anonymous = true;
++
++  if (!anonymous && strcmp (cmp1->name, cmp2->name) != 0)
++    return 0;
++
++  if (cmp1->attr.access != cmp2->attr.access)
++    return 0;
++
++  if (cmp1->attr.pointer != cmp2->attr.pointer)
++    return 0;
++
++  if (cmp1->attr.dimension != cmp2->attr.dimension)
++    return 0;
++
++ if (cmp1->attr.allocatable != cmp2->attr.allocatable)
++    return 0;
++
++  if (cmp1->attr.dimension && gfc_compare_array_spec (cmp1->as, cmp2->as) == 0)
++    return 0;
++
++  /* Make sure that link lists do not put this function into an
++     endless recursive loop!  */
++  if (!(cmp1->ts.type == BT_DERIVED && derived1 == cmp1->ts.u.derived)
++        && !(cmp2->ts.type == BT_DERIVED && derived2 == cmp2->ts.u.derived)
++        && gfc_compare_types (&cmp1->ts, &cmp2->ts) == 0)
++    return 0;
++
++  else if ((cmp1->ts.type == BT_DERIVED && derived1 == cmp1->ts.u.derived)
++            && !(cmp1->ts.type == BT_DERIVED && derived1 == cmp1->ts.u.derived))
++    return 0;
++
++  else if (!(cmp1->ts.type == BT_DERIVED && derived1 == cmp1->ts.u.derived)
++            && (cmp1->ts.type == BT_DERIVED && derived1 == cmp1->ts.u.derived))
++    return 0;
++
++  return 1;
++}
++
++
++/* Compare two union types by comparing the components of their maps.
++   Because unions and maps are anonymous their types get special internal
++   names; therefore the usual derived type comparison will fail on them.
++
++   Returns nonzero if equal, as with gfc_compare_derived_types. Also as with
++   gfc_compare_derived_types, 'equal' is closer to meaning 'duplicate
++   definitions' than 'equivalent structure'. */
++
++int
++gfc_compare_union_types (gfc_symbol *un1, gfc_symbol *un2)
++{
++  gfc_component *map1, *map2, *cmp1, *cmp2;
++
++  if (un1->attr.flavor != FL_UNION || un2->attr.flavor != FL_UNION)
++    return 0;
++
++  map1 = un1->components;
++  map2 = un2->components;
++
++  /* In terms of 'equality' here we are worried about types which are
++     declared the same in two places, not types that represent equivalent
++     structures. (This is common because of FORTRAN's weird scoping rules.)
++     Though two unions with their maps in different orders could be equivalent,
++     we will say they are not equal for the purposes of this test; therefore
++     we compare the maps sequentially. */
++  for (;;)
++  {
++    cmp1 = map1->ts.u.derived->components;
++    cmp2 = map2->ts.u.derived->components;
++    for (;;)
++    {
++      /* No two fields will ever point to the same map type unless they are
++         the same component, because one map field is created with its type
++         declaration. Therefore don't worry about recursion here. */
++      /* TODO: worry about recursion into parent types of the unions? */
++      if (compare_components (cmp1, cmp2,
++            map1->ts.u.derived, map2->ts.u.derived) == 0)
++        return 0;
++
++      cmp1 = cmp1->next;
++      cmp2 = cmp2->next;
++
++      if (cmp1 == NULL && cmp2 == NULL)
++        break;
++      if (cmp1 == NULL || cmp2 == NULL)
++        return 0;
++    }
++
++    map1 = map1->next;
++    map2 = map2->next;
++
++    if (map1 == NULL && map2 == NULL)
++      break;
++    if (map1 == NULL || map2 == NULL)
++      return 0;
++  }
++
++  return 1;
++}
++
++
+ /* Compare two derived types using the criteria in 4.4.2 of the standard,
+    recursing through gfc_compare_types for the components.  */
+ 
+ int
+ gfc_compare_derived_types (gfc_symbol *derived1, gfc_symbol *derived2)
+ {
+-  gfc_component *dt1, *dt2;
++  gfc_component *cmp1, *cmp2;
++  bool anonymous = false;
+ 
+   if (derived1 == derived2)
+     return 1;
+ 
+   gcc_assert (derived1 && derived2);
+ 
++  /* MAP and anonymous STRUCTURE types have internal names of the form
++     mM* and sS* (we can get away with this because source names are converted
++     to lowercase). Compare anonymous type names specially because each
++     gets a unique name when it is declared. */
++  anonymous = (derived1->name[0] == derived2->name[0]
++      && derived1->name[1] && derived2->name[1] && derived2->name[2]
++      && derived1->name[1] == (char) TOUPPER (derived1->name[0])
++      && derived2->name[1] == (char) TOUPPER (derived2->name[0]));
++
+   /* Special case for comparing derived types across namespaces.  If the
+      true names and module names are the same and the module name is
+      nonnull, then they are equal.  */
+@@ -408,12 +531,14 @@ gfc_compare_derived_types (gfc_symbol *derived1, gfc_symbol *derived2)
+       && strcmp (derived1->module, derived2->module) == 0)
+     return 1;
+ 
+-  /* Compare type via the rules of the standard.  Both types must have
+-     the SEQUENCE or BIND(C) attribute to be equal.  */
+-
+-  if (strcmp (derived1->name, derived2->name))
++  if (strcmp (derived1->name, derived2->name) != 0 && !anonymous)
+     return 0;
+ 
++  /* Compare type via the rules of the standard.  Both types must have
++     the SEQUENCE or BIND(C) attribute to be equal. STRUCTUREs are special
++     because they can be anonymous; therefore two structures with different
++     names may be equal.  */
++
+   if (derived1->component_access == ACCESS_PRIVATE
+       || derived2->component_access == ACCESS_PRIVATE)
+     return 0;
+@@ -422,53 +547,30 @@ gfc_compare_derived_types (gfc_symbol *derived1, gfc_symbol *derived2)
+       && !(derived1->attr.is_bind_c && derived2->attr.is_bind_c))
+     return 0;
+ 
+-  dt1 = derived1->components;
+-  dt2 = derived2->components;
++  if ((derived1->attr.zero_comp && !derived2->attr.zero_comp)
++      || (!derived1->attr.zero_comp && derived2->attr.zero_comp))
++    return 0;
++
++  if (derived1->attr.zero_comp || derived2->attr.zero_comp)
++    return 1;
++
++  cmp1 = derived1->components;
++  cmp2 = derived2->components;
+ 
+   /* Since subtypes of SEQUENCE types must be SEQUENCE types as well, a
+      simple test can speed things up.  Otherwise, lots of things have to
+      match.  */
+   for (;;)
+     {
+-      if (strcmp (dt1->name, dt2->name) != 0)
+-	return 0;
+-
+-      if (dt1->attr.access != dt2->attr.access)
+-	return 0;
+-
+-      if (dt1->attr.pointer != dt2->attr.pointer)
+-	return 0;
+-
+-      if (dt1->attr.dimension != dt2->attr.dimension)
+-	return 0;
++      if (!compare_components (cmp1, cmp2, derived1, derived2))
++        return 0;
+ 
+-     if (dt1->attr.allocatable != dt2->attr.allocatable)
+-	return 0;
++      cmp1 = cmp1->next;
++      cmp2 = cmp2->next;
+ 
+-      if (dt1->attr.dimension && gfc_compare_array_spec (dt1->as, dt2->as) == 0)
+-	return 0;
+-
+-      /* Make sure that link lists do not put this function into an
+-	 endless recursive loop!  */
+-      if (!(dt1->ts.type == BT_DERIVED && derived1 == dt1->ts.u.derived)
+-	    && !(dt2->ts.type == BT_DERIVED && derived2 == dt2->ts.u.derived)
+-	    && gfc_compare_types (&dt1->ts, &dt2->ts) == 0)
+-	return 0;
+-
+-      else if ((dt1->ts.type == BT_DERIVED && derived1 == dt1->ts.u.derived)
+-		&& !(dt1->ts.type == BT_DERIVED && derived1 == dt1->ts.u.derived))
+-	return 0;
+-
+-      else if (!(dt1->ts.type == BT_DERIVED && derived1 == dt1->ts.u.derived)
+-		&& (dt1->ts.type == BT_DERIVED && derived1 == dt1->ts.u.derived))
+-	return 0;
+-
+-      dt1 = dt1->next;
+-      dt2 = dt2->next;
+-
+-      if (dt1 == NULL && dt2 == NULL)
++      if (cmp1 == NULL && cmp2 == NULL)
+ 	break;
+-      if (dt1 == NULL || dt2 == NULL)
++      if (cmp1 == NULL || cmp2 == NULL)
+ 	return 0;
+     }
+ 
+@@ -479,7 +581,7 @@ gfc_compare_derived_types (gfc_symbol *derived1, gfc_symbol *derived2)
+ /* Compare two typespecs, recursively if necessary.  */
+ 
+ int
+-gfc_compare_types (gfc_typespec *ts1, gfc_typespec *ts2)
++gfc_compare_types_generic (gfc_typespec *ts1, gfc_typespec *ts2, enum match_type mtype)
+ {
+   /* See if one of the typespecs is a BT_VOID, which is what is being used
+      to allow the funcs like c_f_pointer to accept any pointer type.
+@@ -498,20 +600,35 @@ gfc_compare_types (gfc_typespec *ts1, gfc_typespec *ts2)
+       && (ts1->u.derived->attr.sequence || ts1->u.derived->attr.is_bind_c))
+     return 1;
+ 
++  if (ts1->type == BT_UNION && ts2->type == BT_UNION)
++    return gfc_compare_union_types (ts1->u.derived, ts2->u.derived);
++
+   if (ts1->type != ts2->type
+-      && ((ts1->type != BT_DERIVED && ts1->type != BT_CLASS)
+-	  || (ts2->type != BT_DERIVED && ts2->type != BT_CLASS)))
++      && (   (ts1->type != BT_DERIVED && ts1->type != BT_CLASS)
++          || (ts2->type != BT_DERIVED && ts2->type != BT_CLASS)))
+     return 0;
++
+   if (ts1->type != BT_DERIVED && ts1->type != BT_CLASS)
+-    return (ts1->kind == ts2->kind);
++    {
++    if (mtype == MATCH_PROMOTABLE)
++      return (ts1->kind >= ts2->kind);
++    else
++      return (ts1->kind == ts2->kind);
++    }
++
+ 
+   /* Compare derived types.  */
+   if (gfc_type_compatible (ts1, ts2))
+     return 1;
+ 
+-  return gfc_compare_derived_types (ts1->u.derived ,ts2->u.derived);
++  return 0;
+ }
+ 
++int
++gfc_compare_types (gfc_typespec *ts1, gfc_typespec *ts2)
++{
++  return gfc_compare_types_generic (ts1, ts2, MATCH_EXACT);
++}
+ 
+ static int
+ compare_type (gfc_symbol *s1, gfc_symbol *s2)
+@@ -528,7 +645,9 @@ compare_type (gfc_symbol *s1, gfc_symbol *s2)
+   return gfc_compare_types (&s1->ts, &s2->ts) || s2->ts.type == BT_ASSUMED;
+ }
+ 
+-
++/* Given two symbols that are formal arguments, compare their ranks
++   and types.  Returns nonzero if they have the same rank and type,
++   zero otherwise.  */
+ static int
+ compare_rank (gfc_symbol *s1, gfc_symbol *s2)
+ {
+@@ -1573,7 +1692,7 @@ check_interface0 (gfc_interface *p, const char *interface_name)
+ 	 functions or subroutines.  */
+       if (((!p->sym->attr.function && !p->sym->attr.subroutine)
+ 	   || !p->sym->attr.if_source)
+-	  && p->sym->attr.flavor != FL_DERIVED)
++	  && !gfc_fl_struct (p->sym->attr.flavor))
+ 	{
+ 	  if (p->sym->attr.external)
+ 	    gfc_error ("Procedure %qs in %s at %L has no explicit interface",
+@@ -1587,17 +1706,21 @@ check_interface0 (gfc_interface *p, const char *interface_name)
+ 
+       /* Verify that procedures are either all SUBROUTINEs or all FUNCTIONs.  */
+       if ((psave->sym->attr.function && !p->sym->attr.function
+-	   && p->sym->attr.flavor != FL_DERIVED)
++	   && !gfc_fl_struct (p->sym->attr.flavor))
+ 	  || (psave->sym->attr.subroutine && !p->sym->attr.subroutine))
+ 	{
+-	  if (p->sym->attr.flavor != FL_DERIVED)
++	  if (!gfc_fl_struct (p->sym->attr.flavor))
+ 	    gfc_error ("In %s at %L procedures must be either all SUBROUTINEs"
+ 		       " or all FUNCTIONs", interface_name,
+ 		       &p->sym->declared_at);
+-	  else
++	  else if (p->sym->attr.flavor == FL_DERIVED)
+ 	    gfc_error ("In %s at %L procedures must be all FUNCTIONs as the "
+ 		       "generic name is also the name of a derived type",
+ 		       interface_name, &p->sym->declared_at);
++          else
++            gfc_error ("In %s at %L procedures must be all FUNCTIONs as the "
++                       "generic name is also the name of a structure type",
++                       interface_name, &p->sym->declared_at);
+ 	  return 1;
+ 	}
+ 
+@@ -1654,8 +1777,8 @@ check_interface1 (gfc_interface *p, gfc_interface *q0,
+ 	if (p->sym->name == q->sym->name && p->sym->module == q->sym->module)
+ 	  continue;
+ 
+-	if (p->sym->attr.flavor != FL_DERIVED
+-	    && q->sym->attr.flavor != FL_DERIVED
++	if (!gfc_fl_struct (p->sym->attr.flavor)
++	    && !gfc_fl_struct (q->sym->attr.flavor)
+ 	    && gfc_compare_interfaces (p->sym, q->sym, q->sym->name,
+ 				       generic_flag, 0, NULL, 0, NULL, NULL))
+ 	  {
+@@ -1933,7 +2056,7 @@ argument_rank_mismatch (const char *name, locus *where,
+ 
+ static int
+ compare_parameter (gfc_symbol *formal, gfc_expr *actual,
+-		   int ranks_must_agree, int is_elemental, locus *where)
++                   int ranks_must_agree, int is_elemental, locus *where, enum match_type mtype)
+ {
+   gfc_ref *ref;
+   bool rank_check, is_pointer;
+@@ -2019,7 +2142,7 @@ compare_parameter (gfc_symbol *formal, gfc_expr *actual,
+       && actual->ts.type != BT_HOLLERITH
+       && formal->ts.type != BT_ASSUMED
+       && !(formal->attr.ext_attr & (1 << EXT_ATTR_NO_ARG_CHECK))
+-      && !gfc_compare_types (&formal->ts, &actual->ts)
++      && !gfc_compare_types_generic (&formal->ts, &actual->ts, mtype)
+       && !(formal->ts.type == BT_DERIVED && actual->ts.type == BT_CLASS
+ 	   && gfc_compare_derived_types (formal->ts.u.derived,
+ 					 CLASS_DATA (actual)->ts.u.derived)))
+@@ -2553,7 +2676,8 @@ is_procptr_result (gfc_expr *expr)
+ 
+ static int
+ compare_actual_formal (gfc_actual_arglist **ap, gfc_formal_arglist *formal,
+-	 	       int ranks_must_agree, int is_elemental, locus *where)
++		       int ranks_must_agree, int is_elemental, locus *where,
++		       enum match_type mtype)
+ {
+   gfc_actual_arglist **new_arg, *a, *actual, temp;
+   gfc_formal_arglist *f;
+@@ -2671,7 +2795,7 @@ compare_actual_formal (gfc_actual_arglist **ap, gfc_formal_arglist *formal,
+ 	}
+ 
+       if (!compare_parameter (f->sym, a->expr, ranks_must_agree,
+-			      is_elemental, where))
++			      is_elemental, where, mtype))
+ 	return 0;
+ 
+       /* TS 29113, 6.3p2.  */
+@@ -3397,7 +3521,7 @@ gfc_procedure_use (gfc_symbol *sym, gfc_actual_arglist **ap, locus *where)
+ 
+   dummy_args = gfc_sym_get_dummy_args (sym);
+ 
+-  if (!compare_actual_formal (ap, dummy_args, 0, sym->attr.elemental, where))
++  if (!compare_actual_formal (ap, dummy_args, 0, sym->attr.elemental, where, MATCH_PROMOTABLE))
+     return false;
+ 
+   if (!check_intents (dummy_args, *ap))
+@@ -3446,7 +3570,7 @@ gfc_ppc_use (gfc_component *comp, gfc_actual_arglist **ap, locus *where)
+     }
+ 
+   if (!compare_actual_formal (ap, comp->ts.interface->formal, 0,
+-			      comp->attr.elemental, where))
++			      comp->attr.elemental, where, MATCH_EXACT))
+     return;
+ 
+   check_intents (comp->ts.interface->formal, *ap);
+@@ -3460,7 +3584,7 @@ gfc_ppc_use (gfc_component *comp, gfc_actual_arglist **ap, locus *where)
+    GENERIC resolution.  */
+ 
+ bool
+-gfc_arglist_matches_symbol (gfc_actual_arglist** args, gfc_symbol* sym)
++gfc_arglist_matches_symbol (gfc_actual_arglist** args, gfc_symbol* sym, enum match_type mtype)
+ {
+   gfc_formal_arglist *dummy_args;
+   bool r;
+@@ -3470,7 +3594,7 @@ gfc_arglist_matches_symbol (gfc_actual_arglist** args, gfc_symbol* sym)
+   dummy_args = gfc_sym_get_dummy_args (sym);
+ 
+   r = !sym->attr.elemental;
+-  if (compare_actual_formal (args, dummy_args, r, !r, NULL))
++  if (compare_actual_formal (args, dummy_args, r, !r, NULL, mtype))
+     {
+       check_intents (dummy_args, *args);
+       if (warn_aliasing)
+@@ -3496,7 +3620,8 @@ gfc_search_interface (gfc_interface *intr, int sub_flag,
+   locus null_expr_loc;
+   gfc_actual_arglist *a;
+   bool has_null_arg = false;
+-
++  enum match_type mtypes[] = { MATCH_EXACT, MATCH_PROMOTABLE };
++  int i;
+   for (a = *ap; a; a = a->next)
+     if (a->expr && a->expr->expr_type == EXPR_NULL
+ 	&& a->expr->ts.type == BT_UNKNOWN)
+@@ -3506,38 +3631,41 @@ gfc_search_interface (gfc_interface *intr, int sub_flag,
+ 	break;
+       }
+ 
+-  for (; intr; intr = intr->next)
++  for (i=0; i<2; i++)
+     {
+-      if (intr->sym->attr.flavor == FL_DERIVED)
+-	continue;
+-      if (sub_flag && intr->sym->attr.function)
+-	continue;
+-      if (!sub_flag && intr->sym->attr.subroutine)
+-	continue;
+-
+-      if (gfc_arglist_matches_symbol (ap, intr->sym))
++      for (; intr; intr = intr->next)
+ 	{
+-	  if (has_null_arg && null_sym)
+-	    {
+-	      gfc_error ("MOLD= required in NULL() argument at %L: Ambiguity "
+-			 "between specific functions %s and %s",
+-			 &null_expr_loc, null_sym->name, intr->sym->name);
+-	      return NULL;
+-	    }
+-	  else if (has_null_arg)
+-	    {
+-	      null_sym = intr->sym;
+-	      continue;
+-	    }
++	  if (gfc_fl_struct (intr->sym->attr.flavor))
++	    continue;
++	  if (sub_flag && intr->sym->attr.function)
++	    continue;
++	  if (!sub_flag && intr->sym->attr.subroutine)
++	    continue;
+ 
+-	  /* Satisfy 12.4.4.1 such that an elemental match has lower
+-	     weight than a non-elemental match.  */
+-	  if (intr->sym->attr.elemental)
++	  if (gfc_arglist_matches_symbol (ap, intr->sym, mtypes[i]))
+ 	    {
+-	      elem_sym = intr->sym;
+-	      continue;
++	      if (has_null_arg && null_sym)
++		{
++		  gfc_error ("MOLD= required in NULL() argument at %L: Ambiguity "
++			     "between specific functions %s and %s",
++			     &null_expr_loc, null_sym->name, intr->sym->name);
++		  return NULL;
++		}
++	      else if (has_null_arg)
++		{
++		  null_sym = intr->sym;
++		  continue;
++		}
++
++	      /* Satisfy 12.4.4.1 such that an elemental match has lower
++		 weight than a non-elemental match.  */
++	      if (intr->sym->attr.elemental)
++		{
++		  elem_sym = intr->sym;
++		  continue;
++		}
++	      return intr->sym;
+ 	    }
+-	  return intr->sym;
+ 	}
+     }
+ 
+@@ -3672,7 +3800,7 @@ matching_typebound_op (gfc_expr** tb_base,
+ 
+ 		/* Check if this arglist matches the formal.  */
+ 		argcopy = gfc_copy_actual_arglist (args);
+-		matches = gfc_arglist_matches_symbol (&argcopy, target);
++		matches = gfc_arglist_matches_symbol (&argcopy, target, MATCH_EXACT);
+ 		gfc_free_actual_arglist (argcopy);
+ 
+ 		/* Return if we found a match.  */
+diff --git a/gcc/fortran/intrinsic.c b/gcc/fortran/intrinsic.c
+index a958f8e..7d242f6 100644
+--- a/gcc/fortran/intrinsic.c
++++ b/gcc/fortran/intrinsic.c
+@@ -3633,6 +3633,17 @@ add_conversions (void)
+ 	  add_conv (BT_LOGICAL, gfc_logical_kinds[j].kind,
+ 		    BT_INTEGER, gfc_integer_kinds[i].kind, GFC_STD_LEGACY);
+ 	}
++
++  /* Oracle allows character values to be converted to integers,
++     similar to Hollerith-Integer conversion - the first characters will
++     be turned into ascii values. */
++  if (gfc_option.allow_std & GFC_STD_EXTRA_LEGACY)
++    {
++      /* Character-Integer conversions.  */
++      for (i = 0; gfc_integer_kinds[i].kind != 0; i++)
++	add_conv (BT_CHARACTER, gfc_default_character_kind,
++		  BT_INTEGER, gfc_integer_kinds[i].kind, GFC_STD_LEGACY);
++    }
+ }
+ 
+ 
+@@ -3923,6 +3934,16 @@ check_arglist (gfc_actual_arglist **ap, gfc_intrinsic_sym *sym,
+       if (ts.kind == 0)
+ 	ts.kind = actual->expr->ts.kind;
+ 
++      /* ts.kind is the argument spec. actual is what was passed. */
++
++      if (actual->expr->ts.kind < ts.kind
++	  && ts.type == BT_INTEGER)
++	{
++	  /* If it was OK to overwrite ts.kind in the previous case, it
++	     should be fine here... */
++	  ts.kind = actual->expr->ts.kind;
++	}
++
+       if (!gfc_compare_types (&ts, &actual->expr->ts))
+ 	{
+ 	  if (error_flag)
+@@ -4680,6 +4701,14 @@ gfc_convert_type_warn (gfc_expr *expr, gfc_typespec *ts, int eflag, int wflag)
+ 			     gfc_typename (&from_ts), gfc_typename (ts),
+ 			     &expr->where);
+ 	}
++      else if (gfc_option.allow_std & GFC_STD_EXTRA_LEGACY && from_ts.type == BT_CHARACTER
++	       && ts->type == BT_INTEGER)
++	{
++	  if (warn_conversion_extra || warn_conversion)
++	    gfc_warning_now (OPT_Wconversion, "Conversion from %s to %s at %L",
++			     gfc_typename (&from_ts), gfc_typename (ts),
++			     &expr->where);
++	}
+       else
+         gcc_unreachable ();
+     }
+diff --git a/gcc/fortran/invoke.texi b/gcc/fortran/invoke.texi
+index af123db..aaf93ce 100644
+--- a/gcc/fortran/invoke.texi
++++ b/gcc/fortran/invoke.texi
+@@ -227,6 +227,17 @@ given they are treated as if the first column contained a blank.  If the
+ @option{-fd-lines-as-comments} option is given, they are treated as
+ comment lines.
+ 
++@item -fdec-member-dot
++@opindex @code{fdec-member-dot}
++Enable dot (@code{.}) as a member separator (in addition to the usual @code{%}).
++This is enabled automatically with @option{-fdec-structure}.
++
++@item -fdec-structure
++@opindex @code{fdec-structure}
++Enable DEC old-style @code{STRUCTURE} and @code{RECORD}. This is provided for
++compatibility; Fortran 90 derived types should be used instead where
++possible. This implies @option{-fdec-member-dot}.
++
+ @item -fdollar-ok
+ @opindex @code{fdollar-ok}
+ @cindex @code{$}
+diff --git a/gcc/fortran/io.c b/gcc/fortran/io.c
+index 0ac4f4a..c478a83 100644
+--- a/gcc/fortran/io.c
++++ b/gcc/fortran/io.c
+@@ -707,6 +707,11 @@ format_item_1:
+       error = unexpected_end;
+       goto syntax;
+ 
++    case FMT_RPAREN:
++      /* Oracle allows a blank format item. If this flag is off,
++	 fall through to default. */
++      if (gfc_option.allow_std & GFC_STD_EXTRA_LEGACY) goto finished;
++
+     default:
+       error = unexpected_element;
+       goto syntax;
+@@ -850,6 +855,13 @@ data_desc:
+ 
+       if (u != FMT_POSINT)
+ 	{
++	  if (gfc_option.allow_std & GFC_STD_EXTRA_LEGACY)
++	    {
++	      /* Assume a default width based on the variable size.  */
++	      saved_token = u;
++	      break;
++	    }
++
+ 	  format_locus.nextc += format_string_pos;
+ 	  gfc_error ("Positive width required in format "
+ 			 "specifier %s at %L", token_to_string (t),
+@@ -924,6 +936,11 @@ data_desc:
+ 	goto fail;
+       if (t != FMT_ZERO && t != FMT_POSINT)
+ 	{
++	  if (gfc_option.allow_std & GFC_STD_EXTRA_LEGACY)
++	    {
++	      saved_token = t;
++	      break;
++	    }
+ 	  error = nonneg_required;
+ 	  goto syntax;
+ 	}
+@@ -993,8 +1010,18 @@ data_desc:
+ 	goto fail;
+       if (t != FMT_ZERO && t != FMT_POSINT)
+ 	{
+-	  error = nonneg_required;
+-	  goto syntax;
++	  if (gfc_option.allow_std & GFC_STD_EXTRA_LEGACY)
++	    {
++	      /* Assume the default width is expected here and continue lexing.  */
++	      value = 0; /* It doesn't matter what we set the value to here.  */
++	      saved_token = t;
++	      break;
++	    }
++	  else
++	    {
++	      error = nonneg_required;
++	      goto syntax;
++	    }
+ 	}
+       else if (is_input && t == FMT_ZERO)
+ 	{
+diff --git a/gcc/fortran/lang.opt b/gcc/fortran/lang.opt
+index d86376a..4500695 100644
+--- a/gcc/fortran/lang.opt
++++ b/gcc/fortran/lang.opt
+@@ -412,6 +412,18 @@ fd-lines-as-comments
+ Fortran RejectNegative
+ Treat lines with 'D' in column one as comments
+ 
++fdec-member-dot
++Fortran
++Enable dot (`.`) as a member separator (in addition to the usual `%`).
++
++fdec-static
++Fortran
++Enable STATIC and AUTOMATIC attributes.
++
++fdec-structure
++Fortran
++Enable DEC STRUCTURE extension.
++
+ fdefault-double-8
+ Fortran Var(flag_default_double)
+ Set the default double precision kind to an 8 byte wide type
+@@ -542,6 +554,14 @@ Enum(gfc_init_local_real) String(inf) Value(GFC_INIT_REAL_INF)
+ EnumValue
+ Enum(gfc_init_local_real) String(-inf) Value(GFC_INIT_REAL_NEG_INF)
+ 
++finit-derived
++Fortran
++Automatically initialize local derived type variables
++
++floc-rval
++Fortran
++Enable the use of %LOC as an rvalue, like the built-in LOC().
++
+ fmax-array-constructor=
+ Fortran RejectNegative Joined UInteger Var(flag_max_array_constructor) Init(65535)
+ -fmax-array-constructor=<n>	Maximum number of objects in an array constructor
+@@ -742,6 +762,10 @@ std=legacy
+ Fortran
+ Accept extensions to support legacy code
+ 
++std=extra-legacy
++Fortran
++Accept even more legacy extensions, including things disallowed in f90
++
+ undef
+ Fortran
+ ; Documented in C
+diff --git a/gcc/fortran/libgfortran.h b/gcc/fortran/libgfortran.h
+index df11162..8083dd3 100644
+--- a/gcc/fortran/libgfortran.h
++++ b/gcc/fortran/libgfortran.h
+@@ -24,6 +24,7 @@ along with GCC; see the file COPYING3.  If not see
+    gfortran.texi.  */
+ /* For now, use F2015 = GFC_STD_GNU.  */
+ #define GFC_STD_F2015	        (1<<5)	/* PLACEHOLDER for Fortran 2015.  */
++#define GFC_STD_EXTRA_LEGACY	(1<<10)	/* Even more backward compatibility.  */
+ #define GFC_STD_F2008_TS	(1<<9)	/* POST-F2008 technical reports.  */
+ #define GFC_STD_F2008_OBS	(1<<8)	/* Obsolescent in F2008.  */
+ #define GFC_STD_F2008		(1<<7)	/* New in F2008.  */
+@@ -163,7 +164,7 @@ typedef enum
+    used in the run-time library for IO.  */
+ typedef enum
+ { BT_UNKNOWN = 0, BT_INTEGER, BT_LOGICAL, BT_REAL, BT_COMPLEX,
+-  BT_DERIVED, BT_CHARACTER, BT_CLASS, BT_PROCEDURE, BT_HOLLERITH, BT_VOID,
+-  BT_ASSUMED
++  BT_DERIVED, BT_CHARACTER, BT_CLASS, BT_PROCEDURE, BT_HOLLERITH, BT_UNION,
++  BT_VOID, BT_ASSUMED
+ }
+ bt;
+diff --git a/gcc/fortran/match.c b/gcc/fortran/match.c
+index fd3bd4c..50b8015 100644
+--- a/gcc/fortran/match.c
++++ b/gcc/fortran/match.c
+@@ -36,6 +36,7 @@ along with GCC; see the file COPYING3.  If not see
+ #include "inchash.h"
+ #include "tree.h"
+ #include "stringpool.h"
++#include "arith.h"
+ 
+ int gfc_matching_ptr_assignment = 0;
+ int gfc_matching_procptr_assignment = 0;
+@@ -124,6 +125,126 @@ gfc_op2string (gfc_intrinsic_op op)
+ 
+ /******************** Generic matching subroutines ************************/
+ 
++/* Matches a member separator. With F90+ this is '%', but with
++   -fdec-member-dot we must carefully match dot ('.').
++   Because operators are spelled ".op.", "x.y.z" can be either a component
++   access (x->y)->z or a binary operation y(x,z). Here we choose to deal with
++   the "x.y.z" ambiguity in a manner consistent with Intel:
++     (1) If any user defined operator ".y." exists, this is always y(x,z)
++         (even if ".y." is the wrong type and/or x has a member y).
++     (2) Otherwise if x has a member y, and y is itself a derived type,
++         this is (x->y)->z, even if an intrinsic operator exists which 
++         can handle (x,z). 
++     (3) If x has no member y or (x->y) is not a derived type but ".y." 
++         is an intrinsic operator (such as ".eq."), this is y(x,z).
++     (4) Lastly if there is no operator ".y." and x has no member "y", it is an
++         error.  
++   It is worth noting that [fortunately] Intel does not support mixed use of
++   member accessors within a single string, nor does it support parenthesised
++   member accesses (therefore neither do we).
++   That is, even if x has component y and y has component z, the following
++   are all syntax errors:  "x%y.z"  "x.y%z"  "(x.y).z"  "(x%y)%z"
++ */
++
++match
++gfc_match_member_sep(gfc_symbol *sym)
++{
++    char name[GFC_MAX_SYMBOL_LEN + 1];
++    locus dot_loc, start_loc;
++    gfc_intrinsic_op iop;
++    match m;
++    gfc_symbol *tsym;
++    gfc_component *c;
++
++    /* Thank god; '%' is an unambiguous member separator. */
++    if (gfc_match_char ('%') == MATCH_YES)
++        return MATCH_YES;
++
++    /* Only continue if dot member separators are enabled. */
++    if (!gfc_option.flag_dec_member_dot || !sym)
++        return MATCH_NO;
++
++    tsym = NULL;
++
++    /* We may be given either a derived type variable or the derived type
++       declaration itself (which actually contains the components); 
++       if this is a member access we need the latter to check components. */
++    if (gfc_fl_struct (sym->attr.flavor))
++        tsym = sym;
++    else if (gfc_bt_struct (sym->ts.type))
++        tsym = sym->ts.u.derived;
++    else
++        return MATCH_NO;
++
++    iop = INTRINSIC_NONE;
++    name[0] = '\0';
++    m = MATCH_NO;
++
++    /* If we have to reject, come back here later. */
++    start_loc = gfc_current_locus;
++
++    /* Look for a component access next. */
++    if (gfc_match_char ('.') != MATCH_YES)
++        return MATCH_NO;
++
++    /* If we accept, come back here. */
++    dot_loc = gfc_current_locus;
++
++    /* Try to match a symbol name following '.' */
++    if (gfc_match_name (name) != MATCH_YES)
++    {
++        gfc_error ("Expected structure component or operator name "
++                   "after '.' at %C");
++        goto error;
++    }
++
++    /* If no dot follows we have "x.y" which must be a component access.
++       Ensure the leading symbol is a derived type variable. */
++    if (gfc_match_char ('.') != MATCH_YES)
++        goto yes;
++
++    /* Now we have a string "x.y.z" which could be a nested member access
++       (x->y)->z or a binary operation y on x and z. */
++
++    /* First use any user-defined operators ".y." */
++    if (gfc_find_uop (name, sym->ns) != NULL)
++        goto no;
++
++    /* Match accesses to existing derived-type components for 
++       derived-type vars: "x.y.z" = (x->y)->z */
++    c = gfc_find_component(tsym, name, false, true, NULL);
++    if (c && (c->ts.type == BT_DERIVED || c->ts.type == BT_CLASS))
++        goto yes;
++
++    /* If y is not a component or has no members, try intrinsic operators. */
++    gfc_current_locus = start_loc;
++    if (gfc_match_intrinsic_op (&iop) != MATCH_YES)
++    {
++        /* If ".y." is not an intrinsic operator but y was a valid non-
++           structure component, match and leave the trailing dot to be 
++           dealt with later. */
++        if (c)
++            goto yes;
++
++        gfc_error ("'%s' is neither a defined operator nor a "
++                   "structure component in dotted string at %C", name);
++        goto error;
++    }
++
++    /* .y. is an intrinsic operator, overriding any possible member access. */
++    goto no;
++
++    /* Return keeping the current locus consistent with the match result. */
++error:
++    m = MATCH_ERROR;
++no:
++    gfc_current_locus = start_loc;
++    return m;
++yes:
++    gfc_current_locus = dot_loc;
++    return MATCH_YES;
++}
++
+ /* This function scans the current statement counting the opened and closed
+    parenthesis to make sure they are balanced.  */
+ 
+@@ -840,6 +961,17 @@ gfc_match_intrinsic_op (gfc_intrinsic_op *result)
+ 	    }
+ 	  break;
+ 
++	case 'x':
++	  if (gfc_next_ascii_char () == 'o'
++	      && gfc_next_ascii_char () == 'r'
++	      && gfc_next_ascii_char () == '.')
++	    {
++	      /* Matched ".xor.".  */
++	      *result = INTRINSIC_NEQV;
++	      return MATCH_YES;
++	    }
++	  break;
++
+ 	default:
+ 	  break;
+ 	}
+@@ -1533,7 +1665,16 @@ got_match:
+   *p->next = new_st;
+   p->next->loc = gfc_current_locus;
+ 
+-  p->expr1 = expr;
++  if (gfc_option.allow_std & GFC_STD_EXTRA_LEGACY && expr->ts.type != BT_LOGICAL)
++    {
++      p->expr1 = gfc_ne (expr, gfc_get_int_expr (1, &gfc_current_locus, 0), INTRINSIC_NE);
++      gfc_warning_now (0, "The type of condition in this IF statement isn't LOGICAL; it will be true if it evaluates to nonzero.");
++    }
++  else
++    {
++      p->expr1 = expr;
++    }
++  p->op = EXEC_IF;
+ 
+   gfc_clear_new_st ();
+ 
+@@ -1837,7 +1978,7 @@ match_derived_type_spec (gfc_typespec *ts)
+   if (derived && derived->attr.flavor == FL_PROCEDURE && derived->attr.generic)
+     derived = gfc_find_dt_in_generic (derived);
+ 
+-  if (derived && derived->attr.flavor == FL_DERIVED)
++  if (derived && gfc_fl_struct (derived->attr.flavor))
+     {
+       ts->type = BT_DERIVED;
+       ts->u.derived = derived;
+@@ -5163,7 +5304,7 @@ select_intrinsic_set_tmp (gfc_typespec *ts)
+   gfc_symtree *tmp;
+   int charlen = 0;
+ 
+-  if (ts->type == BT_CLASS || ts->type == BT_DERIVED)
++  if (ts->type == BT_CLASS || gfc_bt_struct (ts->type))
+     return NULL;
+ 
+   if (select_type_stack->selector->ts.type == BT_CLASS
+diff --git a/gcc/fortran/match.h b/gcc/fortran/match.h
+index 96d3ec1..8d34539 100644
+--- a/gcc/fortran/match.h
++++ b/gcc/fortran/match.h
+@@ -60,7 +60,7 @@ match gfc_match (const char *, ...);
+ match gfc_match_iterator (gfc_iterator *, int);
+ match gfc_match_parens (void);
+ match gfc_match_type_spec (gfc_typespec *);
+-
++match gfc_match_member_sep(gfc_symbol *);
+ 
+ /* Statement matchers.  */
+ match gfc_match_program (void);
+@@ -203,8 +203,12 @@ match gfc_match_generic (void);
+ match gfc_match_function_decl (void);
+ match gfc_match_entry (void);
+ match gfc_match_subroutine (void);
++match gfc_match_map (void);
++match gfc_match_union (void);
++match gfc_match_structure_decl (void);
+ match gfc_match_derived_decl (void);
+ match gfc_match_final_decl (void);
++match gfc_match_type (gfc_statement *);
+ 
+ match gfc_match_implicit_none (void);
+ match gfc_match_implicit (void);
+@@ -229,12 +233,14 @@ match gfc_match_protected (void);
+ match gfc_match_private (gfc_statement *);
+ match gfc_match_public (gfc_statement *);
+ match gfc_match_save (void);
++match gfc_match_automatic (void);
+ match gfc_match_modproc (void);
+ match gfc_match_target (void);
+ match gfc_match_value (void);
+ match gfc_match_volatile (void);
+ 
+ /* decl.c.  */
++match gfc_match_clist_expr (gfc_expr **, gfc_typespec *, bool);
+ 
+ /* Fortran 2003 c interop.
+    TODO: some of these should be moved to another file rather than decl.c */
+diff --git a/gcc/fortran/misc.c b/gcc/fortran/misc.c
+index 34ed04a..b445ad2 100644
+--- a/gcc/fortran/misc.c
++++ b/gcc/fortran/misc.c
+@@ -83,6 +83,9 @@ gfc_basic_typename (bt type)
+     case BT_HOLLERITH:
+       p = "HOLLERITH";
+       break;
++    case BT_UNION:
++      p = "UNION";
++      break;
+     case BT_DERIVED:
+       p = "DERIVED";
+       break;
+@@ -144,6 +147,9 @@ gfc_typename (gfc_typespec *ts)
+     case BT_HOLLERITH:
+       sprintf (buffer, "HOLLERITH");
+       break;
++    case BT_UNION:
++      sprintf (buffer, "UNION(%s)", ts->u.derived->name);
++      break;
+     case BT_DERIVED:
+       sprintf (buffer, "TYPE(%s)", ts->u.derived->name);
+       break;
+diff --git a/gcc/fortran/module.c b/gcc/fortran/module.c
+index 2a7e986..35c912a 100644
+--- a/gcc/fortran/module.c
++++ b/gcc/fortran/module.c
+@@ -423,8 +423,8 @@ resolve_fixups (fixup_t *f, void *gp)
+    to convert the symtree name of a derived-type to the symbol name or to
+    the name of the associated generic function.  */
+ 
+-static const char *
+-dt_lower_string (const char *name)
++const char *
++gfc_dt_lower_string (const char *name)
+ {
+   if (name[0] != (char) TOLOWER ((unsigned char) name[0]))
+     return gfc_get_string ("%c%s", (char) TOLOWER ((unsigned char) name[0]),
+@@ -438,8 +438,8 @@ dt_lower_string (const char *name)
+    symtree/symbol name of the associated generic function start with a lower-
+    case character.  */
+ 
+-static const char *
+-dt_upper_string (const char *name)
++const char *
++gfc_dt_upper_string (const char *name)
+ {
+   if (name[0] != (char) TOUPPER ((unsigned char) name[0]))
+     return gfc_get_string ("%c%s", (char) TOUPPER ((unsigned char) name[0]),
+@@ -739,7 +739,7 @@ find_use_name_n (const char *name, int *inst, bool interface)
+ 
+   /* For derived types.  */
+   if (name[0] != (char) TOLOWER ((unsigned char) name[0]))
+-    low_name = dt_lower_string (name);
++    low_name = gfc_dt_lower_string (name);
+ 
+   i = 0;
+   for (u = gfc_rename_list; u; u = u->next)
+@@ -768,7 +768,7 @@ find_use_name_n (const char *name, int *inst, bool interface)
+     {
+       if (u->local_name[0] == '\0')
+ 	return name;
+-      return dt_upper_string (u->local_name);
++      return gfc_dt_upper_string (u->local_name);
+     }
+ 
+   return (u->local_name[0] != '\0') ? u->local_name : name;
+@@ -896,8 +896,8 @@ add_true_name (gfc_symbol *sym)
+ 
+   t = XCNEW (true_name);
+   t->sym = sym;
+-  if (sym->attr.flavor == FL_DERIVED)
+-    t->name = dt_upper_string (sym->name);
++  if (gfc_fl_struct (sym->attr.flavor))
++    t->name = gfc_dt_upper_string (sym->name);
+   else
+     t->name = sym->name;
+ 
+@@ -918,8 +918,8 @@ build_tnt (gfc_symtree *st)
+   build_tnt (st->left);
+   build_tnt (st->right);
+ 
+-  if (st->n.sym->attr.flavor == FL_DERIVED)
+-    name = dt_upper_string (st->n.sym->name);
++  if (gfc_fl_struct (st->n.sym->attr.flavor))
++    name = gfc_dt_upper_string (st->n.sym->name);
+   else
+     name = st->n.sym->name;
+ 
+@@ -2314,6 +2314,7 @@ static const mstring bt_types[] = {
+     minit ("COMPLEX", BT_COMPLEX),
+     minit ("LOGICAL", BT_LOGICAL),
+     minit ("CHARACTER", BT_CHARACTER),
++    minit ("UNION", BT_UNION),
+     minit ("DERIVED", BT_DERIVED),
+     minit ("CLASS", BT_CLASS),
+     minit ("PROCEDURE", BT_PROCEDURE),
+@@ -2367,7 +2368,7 @@ mio_typespec (gfc_typespec *ts)
+ 
+   ts->type = MIO_NAME (bt) (ts->type, bt_types);
+ 
+-  if (ts->type != BT_DERIVED && ts->type != BT_CLASS)
++  if (!gfc_bt_struct (ts->type) && ts->type != BT_CLASS)
+     mio_integer (&ts->kind);
+   else
+     mio_symbol_ref (&ts->u.derived);
+@@ -3184,8 +3185,8 @@ fix_mio_expr (gfc_expr *e)
+       if (e->symtree->n.sym && check_unique_name (e->symtree->name))
+ 	{
+           const char *name = e->symtree->n.sym->name;
+-	  if (e->symtree->n.sym->attr.flavor == FL_DERIVED)
+-	    name = dt_upper_string (name);
++	  if (gfc_fl_struct (e->symtree->n.sym->attr.flavor))
++	    name = gfc_dt_upper_string (name);
+ 	  ns_st = gfc_find_symtree (gfc_current_ns->sym_root, name);
+ 	}
+ 
+@@ -4127,7 +4128,7 @@ mio_symbol (gfc_symbol *sym)
+   
+   mio_integer (&(sym->intmod_sym_id));
+ 
+-  if (sym->attr.flavor == FL_DERIVED)
++  if (gfc_fl_struct (sym->attr.flavor))
+     mio_integer (&(sym->hash_value));
+ 
+   if (sym->formal_ns
+@@ -4707,7 +4708,7 @@ load_needed (pointer_info *p)
+ 				 1, &ns->proc_name);
+ 
+       sym = gfc_new_symbol (p->u.rsym.true_name, ns);
+-      sym->name = dt_lower_string (p->u.rsym.true_name);
++      sym->name = gfc_dt_lower_string (p->u.rsym.true_name);
+       sym->module = gfc_get_string (p->u.rsym.module);
+       if (p->u.rsym.binding_label)
+ 	sym->binding_label = IDENTIFIER_POINTER (get_identifier 
+@@ -4719,6 +4720,12 @@ load_needed (pointer_info *p)
+   mio_symbol (sym);
+   sym->attr.use_assoc = 1;
+ 
++  /* Unliked derived types, a STRUCTURE may share names with other symbols.
++     We greedily converted the the symbol name to lowercase before we knew its
++     type, so now we must fix it. */
++  if (sym->attr.flavor == FL_STRUCT)
++    sym->name = gfc_dt_upper_string (sym->name);
++
+   /* Mark as only or rename for later diagnosis for explicitly imported
+      but not used warnings; don't mark internal symbols such as __vtab,
+      __def_init etc. Only mark them if they have been explicitly loaded.  */
+@@ -4921,7 +4928,7 @@ read_module (void)
+ 	 can be used in expressions in the module.  To avoid the module loading
+ 	 failing, we need to associate the module's component pointer indexes
+ 	 with the existing symbol's component pointers.  */
+-      if (sym->attr.flavor == FL_DERIVED)
++      if (gfc_fl_struct (sym->attr.flavor))
+ 	{
+ 	  gfc_component *c;
+ 
+@@ -5065,7 +5072,7 @@ read_module (void)
+ 		{
+ 		  info->u.rsym.sym = gfc_new_symbol (info->u.rsym.true_name,
+ 						     gfc_current_ns);
+-		  info->u.rsym.sym->name = dt_lower_string (info->u.rsym.true_name);
++		  info->u.rsym.sym->name = gfc_dt_lower_string (info->u.rsym.true_name);
+ 		  sym = info->u.rsym.sym;
+ 		  sym->module = gfc_get_string (info->u.rsym.module);
+ 
+@@ -5404,10 +5411,10 @@ write_symbol (int n, gfc_symbol *sym)
+ 
+   mio_integer (&n);
+ 
+-  if (sym->attr.flavor == FL_DERIVED)
++  if (gfc_fl_struct (sym->attr.flavor))
+     {
+       const char *name;
+-      name = dt_upper_string (sym->name);
++      name = gfc_dt_upper_string (sym->name);
+       mio_pool_string (&name);
+     }
+   else
+@@ -6381,7 +6388,7 @@ create_derived_type (const char *name, const char *modname,
+   sym->attr.function = 1;
+   sym->attr.generic = 1;
+ 
+-  gfc_get_sym_tree (dt_upper_string (sym->name),
++  gfc_get_sym_tree (gfc_dt_upper_string (sym->name),
+ 		    gfc_current_ns, &tmp_symtree, false);
+   dt_sym = tmp_symtree->n.sym;
+   dt_sym->name = gfc_get_string (sym->name);
+diff --git a/gcc/fortran/options.c b/gcc/fortran/options.c
+index 1262ccc..91a1fdc 100644
+--- a/gcc/fortran/options.c
++++ b/gcc/fortran/options.c
+@@ -703,6 +703,12 @@ gfc_handle_option (size_t scode, const char *arg, int value,
+       gfc_option.warn_std = 0;
+       break;
+ 
++    case OPT_std_extra_legacy:
++      set_default_std_flags ();
++      gfc_option.warn_std = 0;
++      gfc_option.allow_std |= GFC_STD_EXTRA_LEGACY;
++      break;
++
+     case OPT_fshort_enums:
+       /* Handled in language-independent code.  */
+       break;
+@@ -710,6 +716,14 @@ gfc_handle_option (size_t scode, const char *arg, int value,
+     case OPT_fcheck_:
+       gfc_handle_runtime_check_option (arg);
+       break;
++
++    case OPT_fdec_structure:
++      gfc_option.flag_dec_structure = 1;
++      /* Fall-through: -fdec-structure implies -fdec-member-dot. */
++
++    case OPT_fdec_member_dot:
++      gfc_option.flag_dec_member_dot = 1;
++      break;
+     }
+ 
+   Fortran_handle_option_auto (&global_options, &global_options_set, 
+diff --git a/gcc/fortran/parse.c b/gcc/fortran/parse.c
+index f22b191..33a7868 100644
+--- a/gcc/fortran/parse.c
++++ b/gcc/fortran/parse.c
+@@ -27,6 +27,7 @@ along with GCC; see the file COPYING3.  If not see
+ #include "match.h"
+ #include "parse.h"
+ #include "debug.h"
++#include "arith.h"
+ 
+ /* Current statement label.  Zero means no statement label.  Because new_st
+    can get wiped during statement matching, we have to keep it separate.  */
+@@ -193,6 +194,7 @@ decode_specification_statement (void)
+ 	     ST_INTERFACE);
+       match ("allocatable", gfc_match_allocatable, ST_ATTR_DECL);
+       match ("asynchronous", gfc_match_asynchronous, ST_ATTR_DECL);
++      match ("automatic", gfc_match_automatic, ST_ATTR_DECL);
+       break;
+ 
+     case 'b':
+@@ -258,6 +260,7 @@ decode_specification_statement (void)
+ 
+     case 's':
+       match ("save", gfc_match_save, ST_ATTR_DECL);
++      match ("structure", gfc_match_structure_decl, ST_STRUCTURE_DECL);
+       break;
+ 
+     case 't':
+@@ -415,6 +418,7 @@ decode_statement (void)
+       match ("allocatable", gfc_match_allocatable, ST_ATTR_DECL);
+       match ("assign", gfc_match_assign, ST_LABEL_ASSIGNMENT);
+       match ("asynchronous", gfc_match_asynchronous, ST_ATTR_DECL);
++      match ("automatic", gfc_match_automatic, ST_ATTR_DECL);
+       break;
+ 
+     case 'b':
+@@ -485,6 +489,7 @@ decode_statement (void)
+       break;
+ 
+     case 'm':
++      match ("map", gfc_match_map, ST_MAP);
+       match ("module% procedure", gfc_match_modproc, ST_MODULE_PROC);
+       match ("module", gfc_match_module, ST_MODULE);
+       break;
+@@ -520,6 +525,8 @@ decode_statement (void)
+       break;
+ 
+     case 's':
++      // DEC extension: treat STRUCTURE /name/ ... as TYPE name ...
++      match ("structure", gfc_match_structure_decl, ST_STRUCTURE_DECL);
+       match ("sequence", gfc_match_eos, ST_SEQUENCE);
+       match ("stop", gfc_match_stop, ST_STOP);
+       match ("save", gfc_match_save, ST_ATTR_DECL);
+@@ -535,6 +542,7 @@ decode_statement (void)
+       break;
+ 
+     case 'u':
++      match ("union", gfc_match_union, ST_UNION);
+       match ("unlock", gfc_match_unlock, ST_UNLOCK);
+       break;
+ 
+@@ -1549,6 +1557,68 @@ gfc_enclosing_unit (gfc_compile_state * result)
+   return NULL;
+ }
+ 
++/* Translate a compile state to an ascii string. */
++
++const char *
++gfc_ascii_comp_state(gfc_compile_state c)
++{
++    const char *p = "NONE";
++    switch(c) {
++    case COMP_PROGRAM:
++        p = "PROGRAM"; break;
++    case COMP_MODULE:
++        p = "MODULE"; break;
++    case COMP_SUBROUTINE:
++        p = "SUBROUTINE"; break;
++    case COMP_FUNCTION:
++        p = "FUNCTION"; break;
++    case COMP_BLOCK_DATA:
++        p = "BLOCK DATA"; break;
++    case COMP_INTERFACE:
++        p = "INTERFACE"; break;
++    case COMP_DERIVED:
++        p = "DERIVED"; break;
++    case COMP_DERIVED_CONTAINS:
++        p = "DERIVED CONTAINS"; break;
++    case COMP_UNION:
++        p = "UNION"; break;
++    case COMP_MAP:
++        p = "MAP"; break;
++    case COMP_STRUCTURE:
++        p = "STRUCTURE"; break;
++    case COMP_BLOCK:
++        p = "BLOCK"; break;
++    case COMP_ASSOCIATE:
++        p = "ASSOCIATE"; break;
++    case COMP_IF:
++        p = "IF"; break;
++    case COMP_DO:
++        p = "DO"; break;
++    case COMP_SELECT:
++        p = "SELECT"; break;
++    case COMP_FORALL:
++        p = "FORALL"; break;
++    case COMP_WHERE:
++        p = "WHERE"; break;
++    case COMP_CONTAINS:
++        p = "CONTAINS"; break;
++    case COMP_ENUM:
++        p = "ENUM"; break;
++    case COMP_SELECT_TYPE:
++        p = "SELECT TYPE"; break;
++    case COMP_OMP_STRUCTURED_BLOCK:
++        p = "OMP STRUCTURED BLOCK"; break;
++    case COMP_CRITICAL:
++        p = "CRITICAL"; break;
++    case COMP_DO_CONCURRENT:
++        p = "CONCURRENT DO"; break;
++    case COMP_NONE:
++    default:
++        break;
++    }
++    return p;
++}
++
+ 
+ /* Translate a statement enum to a string.  */
+ 
+@@ -1613,6 +1683,15 @@ gfc_ascii_statement (gfc_statement st)
+     case ST_DEALLOCATE:
+       p = "DEALLOCATE";
+       break;
++    case ST_MAP:
++      p = "MAP";
++      break;
++    case ST_UNION:
++      p = "UNION";
++      break;
++    case ST_STRUCTURE_DECL:
++      p = "STRUCTURE";
++      break;
+     case ST_DERIVED_DECL:
+       p = _("derived type declaration");
+       break;
+@@ -1673,6 +1752,15 @@ gfc_ascii_statement (gfc_statement st)
+     case ST_END_WHERE:
+       p = "END WHERE";
+       break;
++    case ST_END_STRUCTURE:
++      p = "END STRUCTURE";
++      break;
++    case ST_END_UNION:
++      p = "END UNION";
++      break;
++    case ST_END_MAP:
++      p = "END MAP";
++      break;
+     case ST_END_TYPE:
+       p = "END TYPE";
+       break;
+@@ -2409,6 +2497,7 @@ verify_st_order (st_state *p, gfc_statement st, bool silent)
+ 
+     case ST_PUBLIC:
+     case ST_PRIVATE:
++    case ST_STRUCTURE_DECL:
+     case ST_DERIVED_DECL:
+     case ST_OACC_DECLARE:
+     case_decl:
+@@ -2598,6 +2687,348 @@ error:
+   return error_flag;
+ }
+ 
++/* Set attributes for the parent symbol (gfc_symbol*)data based on the
++   attributes of a component, and raise errors if conflicting attributes
++   are found for the component. */
++
++static void
++check_component (gfc_component *c, gfc_symbol *sym, gfc_component **lockp)
++{
++  gfc_component *lock_comp = NULL;
++  bool coarray, lock_type, allocatable, pointer;
++  coarray = lock_type = allocatable = pointer = false;
++
++  if (lockp) lock_comp = *lockp;
++
++  /* Look for allocatable components.  */
++  if (c->attr.allocatable
++      || (c->ts.type == BT_CLASS && c->attr.class_ok
++          && CLASS_DATA (c)->attr.allocatable)
++      || (c->ts.type == BT_DERIVED && !c->attr.pointer
++          && c->ts.u.derived->attr.alloc_comp))
++    {
++      allocatable = true;
++      sym->attr.alloc_comp = 1;
++    }
++
++  /* Look for pointer components.  */
++  if (c->attr.pointer
++      || (c->ts.type == BT_CLASS && c->attr.class_ok
++          && CLASS_DATA (c)->attr.class_pointer)
++      || (c->ts.type == BT_DERIVED && c->ts.u.derived->attr.pointer_comp))
++    {
++      pointer = true;
++      sym->attr.pointer_comp = 1;
++    }
++
++  /* Look for procedure pointer components.  */
++  if (c->attr.proc_pointer
++      || (c->ts.type == BT_DERIVED
++          && c->ts.u.derived->attr.proc_pointer_comp))
++    sym->attr.proc_pointer_comp = 1;
++
++  /* Looking for coarray components.  */
++  if (c->attr.codimension
++      || (c->ts.type == BT_CLASS && c->attr.class_ok
++          && CLASS_DATA (c)->attr.codimension))
++    {
++      coarray = true;
++      sym->attr.coarray_comp = 1;
++    }
++ 
++  if (c->ts.type == BT_DERIVED && c->ts.u.derived->attr.coarray_comp && !c->attr.pointer)
++    {
++      coarray = true;
++      sym->attr.coarray_comp = 1;
++    }
++
++  /* Looking for lock_type components.  */
++  if ((c->ts.type == BT_DERIVED
++          && c->ts.u.derived->from_intmod == INTMOD_ISO_FORTRAN_ENV
++          && c->ts.u.derived->intmod_sym_id == ISOFORTRAN_LOCK_TYPE)
++      || (c->ts.type == BT_CLASS && c->attr.class_ok
++          && CLASS_DATA (c)->ts.u.derived->from_intmod
++             == INTMOD_ISO_FORTRAN_ENV
++          && CLASS_DATA (c)->ts.u.derived->intmod_sym_id
++             == ISOFORTRAN_LOCK_TYPE)
++      || (c->ts.type == BT_DERIVED && c->ts.u.derived->attr.lock_comp
++          && !allocatable && !pointer))
++    {
++      lock_type = 1;
++      lock_comp = c;
++      sym->attr.lock_comp = 1;
++    }
++
++  /* Check for F2008, C1302 - and recall that pointers may not be coarrays
++     (5.3.14) and that subobjects of coarray are coarray themselves (2.4.7),
++     unless there are nondirect [allocatable or pointer] components
++     involved (cf. 1.3.33.1 and 1.3.33.3).  */
++
++  if (pointer && !coarray && lock_type)
++    gfc_error ("Component %s at %L of type LOCK_TYPE must have a "
++               "codimension or be a subcomponent of a coarray, "
++               "which is not possible as the component has the "
++               "pointer attribute", c->name, &c->loc);
++  else if (pointer && !coarray && c->ts.type == BT_DERIVED
++           && c->ts.u.derived->attr.lock_comp)
++    gfc_error ("Pointer component %s at %L has a noncoarray subcomponent "
++               "of type LOCK_TYPE, which must have a codimension or be a "
++               "subcomponent of a coarray", c->name, &c->loc);
++
++  if (lock_type && allocatable && !coarray)
++    gfc_error ("Allocatable component %s at %L of type LOCK_TYPE must have "
++               "a codimension", c->name, &c->loc);
++  else if (lock_type && allocatable && c->ts.type == BT_DERIVED
++           && c->ts.u.derived->attr.lock_comp)
++    gfc_error ("Allocatable component %s at %L must have a codimension as "
++               "it has a noncoarray subcomponent of type LOCK_TYPE",
++               c->name, &c->loc);
++
++  if (sym->attr.coarray_comp && !coarray && lock_type)
++    gfc_error ("Noncoarray component %s at %L of type LOCK_TYPE or with "
++               "subcomponent of type LOCK_TYPE must have a codimension or "
++               "be a subcomponent of a coarray. (Variables of type %s may "
++               "not have a codimension as already a coarray "
++               "subcomponent exists)", c->name, &c->loc, sym->name);
++
++  if (sym->attr.lock_comp && coarray && !lock_type)
++    gfc_error_1 ("Noncoarray component %s at %L of type LOCK_TYPE or with "
++               "subcomponent of type LOCK_TYPE must have a codimension or "
++               "be a subcomponent of a coarray. (Variables of type %s may "
++               "not have a codimension as %s at %L has a codimension or a "
++               "coarray subcomponent)", lock_comp->name, &lock_comp->loc,
++               sym->name, c->name, &c->loc);
++
++  /* Look for private components.  */
++  if (sym->component_access == ACCESS_PRIVATE
++      || c->attr.access == ACCESS_PRIVATE
++      || (c->ts.type == BT_DERIVED && c->ts.u.derived->attr.private_comp))
++    sym->attr.private_comp = 1;
++
++  if (lockp) *lockp = lock_comp;
++}
++
++static void parse_map (void);
++
++/* Parse a union component definition within a structure/derived-type 
++   definition. */
++
++static void
++parse_union (void)
++{
++    int compiling;
++    gfc_statement st;
++    gfc_state_data s;
++    gfc_component *c;
++    gfc_symbol *un;
++
++    accept_statement(ST_UNION);
++    push_state (&s, COMP_UNION, gfc_new_block);
++    un = gfc_new_block;
++
++    compiling = 1;
++
++    while (compiling)
++    {
++      st = next_statement ();
++      /* Only MAP declarations valid within a union. */
++      switch (st)
++        {
++        case ST_NONE:
++          unexpected_eof ();
++
++        case ST_MAP:
++          accept_statement (ST_MAP);
++          parse_map ();
++          /* Add a component to the union for each map. */
++          if (!gfc_add_component (un, gfc_new_block->name, &c))
++          {
++            gfc_internal_error ("failed to create map component '%s'", 
++                gfc_new_block->name);
++            reject_statement ();
++            return;
++          }
++          c->ts.type = BT_DERIVED;
++          c->ts.u.derived = gfc_new_block;
++          break;
++
++        case ST_END_UNION:
++          compiling = 0;
++          accept_statement (ST_END_UNION);
++          break;
++
++        default:
++          gfc_error ("Unexpected statement at %C; only MAP blocks are valid in"
++                     " a UNION block");
++          reject_statement ();
++          break;
++        }
++    }
++
++    for (c = un->components; c; c = c->next)
++      check_component (c, un, NULL);
++
++    /* Add the union as a component in its parent structure. */
++    pop_state ();
++    if (!gfc_add_component (gfc_current_block (), un->name, &c))
++    {
++      gfc_internal_error ("failed to create union component '%s'", un->name);
++      reject_statement ();
++      return;
++    }
++    c->ts.type = BT_UNION;
++    c->ts.u.derived = un;
++
++    un->attr.zero_comp = un->components == NULL;
++}
++
++/* Parse a structure definition. */
++
++static void
++parse_structure (void)
++{ 
++    int compiling_type;
++    gfc_statement st;
++    gfc_state_data s;
++    gfc_symbol *sym;
++    gfc_component *c;
++
++    accept_statement(ST_STRUCTURE_DECL);
++    push_state (&s, COMP_STRUCTURE, gfc_new_block);
++
++    gfc_new_block->component_access = ACCESS_PUBLIC;
++    compiling_type = 1;
++
++    while (compiling_type)
++    {
++      st = next_statement ();
++      switch (st)
++        {
++        case ST_NONE:
++          unexpected_eof ();
++          break;
++
++        /* Nested structure declarations should be captured as ST_DATA_DECL. */
++        case ST_STRUCTURE_DECL:
++          /* Let a more specific error take over. */
++          if (gfc_error_check () == 0)
++            gfc_error ("Syntax error in nested structure declaration at %C");
++          reject_statement ();
++          /* Skip the rest of this statement. */
++          gfc_error_recovery ();
++          break;
++
++        case ST_UNION:
++          accept_statement (ST_UNION);
++          parse_union ();
++          break;
++
++        case ST_DATA_DECL:
++          accept_statement (ST_DATA_DECL);
++          /* The data declaration was a nested/ad-hoc STRUCTURE field */
++          if (gfc_new_block && gfc_new_block != gfc_current_block ()
++                            && gfc_new_block->attr.flavor == FL_STRUCT)
++              parse_structure ();
++          break;
++
++        case ST_END_STRUCTURE:
++          compiling_type = 0;
++          accept_statement (ST_END_STRUCTURE);
++          break;
++
++        default:
++          unexpected_statement (st);
++          break;
++        }
++    }
++
++    /* need to verify that all fields of the derived type are
++    * interoperable with C if the type is declared to be bind(c)
++    */
++    sym = gfc_current_block ();
++    for (c = sym->components; c; c = c->next)
++      check_component (c, sym, NULL);
++
++    sym->attr.zero_comp = sym->components == NULL;
++
++    pop_state ();
++
++}
++
++/* Parse a map definition within a union. Similar to a structure definition
++   itself. */
++
++static void
++parse_map (void)
++{
++    int compiling_type;
++    gfc_statement st;
++    gfc_state_data s;
++    gfc_symbol *sym;
++    gfc_component *c;
++
++    accept_statement(ST_MAP);
++    push_state (&s, COMP_MAP, gfc_new_block);
++
++    gfc_new_block->component_access = ACCESS_PUBLIC;
++    compiling_type = 1;
++
++    while (compiling_type)
++    {
++      st = next_statement ();
++      switch (st)
++        {
++        case ST_NONE:
++          unexpected_eof ();
++
++        /* Nested structure declarations should be captured as ST_DATA_DECL. */
++        case ST_STRUCTURE_DECL:
++          /* Let a more specific error make it to decode_statement(). */
++          if (gfc_error_check () == 0)
++            gfc_error ("Syntax error in nested structure declaration at %C");
++          reject_statement ();
++          /* Skip the rest of this statement. */
++          gfc_error_recovery ();
++          break;
++
++        case ST_UNION:
++          accept_statement (ST_UNION);
++          parse_union ();
++          break;
++
++        case ST_DATA_DECL:
++          accept_statement (ST_DATA_DECL);
++          /* The data declaration was a nested/ad-hoc STRUCTURE field */
++          if (gfc_new_block && gfc_new_block != gfc_current_block ()
++                            && gfc_new_block->attr.flavor == FL_STRUCT)
++              parse_structure ();
++          break;
++
++        case ST_END_MAP:
++          compiling_type = 0;
++          accept_statement (ST_END_MAP);
++          break;
++
++        default:
++          unexpected_statement (st);
++          break;
++        }
++    }
++
++    /* need to verify that all fields of the derived type are
++    * interoperable with C if the type is declared to be bind(c)
++    */
++    sym = gfc_current_block ();
++    for (c = sym->components; c; c = c->next)
++      check_component (c, sym, NULL);
++
++    sym->attr.zero_comp = sym->components == NULL;
++
++    /* So parse_union can add this structure to its list of maps */
++    gfc_new_block = gfc_current_block ();
++
++    pop_state ();
++}
+ 
+ /* Parse a derived type.  */
+ 
+@@ -2715,119 +3146,10 @@ endType:
+    */
+   sym = gfc_current_block ();
+   for (c = sym->components; c; c = c->next)
+-    {
+-      bool coarray, lock_type, allocatable, pointer;
+-      coarray = lock_type = allocatable = pointer = false;
+-
+-      /* Look for allocatable components.  */
+-      if (c->attr.allocatable
+-	  || (c->ts.type == BT_CLASS && c->attr.class_ok
+-	      && CLASS_DATA (c)->attr.allocatable)
+-	  || (c->ts.type == BT_DERIVED && !c->attr.pointer
+-	      && c->ts.u.derived->attr.alloc_comp))
+-	{
+-	  allocatable = true;
+-	  sym->attr.alloc_comp = 1;
+-	}
++    check_component (c, sym, &lock_comp);
+ 
+-      /* Look for pointer components.  */
+-      if (c->attr.pointer
+-	  || (c->ts.type == BT_CLASS && c->attr.class_ok
+-	      && CLASS_DATA (c)->attr.class_pointer)
+-	  || (c->ts.type == BT_DERIVED && c->ts.u.derived->attr.pointer_comp))
+-	{
+-	  pointer = true;
+-	  sym->attr.pointer_comp = 1;
+-	}
+ 
+-      /* Look for procedure pointer components.  */
+-      if (c->attr.proc_pointer
+-	  || (c->ts.type == BT_DERIVED
+-	      && c->ts.u.derived->attr.proc_pointer_comp))
+-	sym->attr.proc_pointer_comp = 1;
+-
+-      /* Looking for coarray components.  */
+-      if (c->attr.codimension
+-	  || (c->ts.type == BT_CLASS && c->attr.class_ok
+-	      && CLASS_DATA (c)->attr.codimension))
+-	{
+-	  coarray = true;
+-	  sym->attr.coarray_comp = 1;
+-	}
+-     
+-      if (c->ts.type == BT_DERIVED && c->ts.u.derived->attr.coarray_comp
+-	  && !c->attr.pointer)
+-	{
+-	  coarray = true;
+-	  sym->attr.coarray_comp = 1;
+-	}
+-
+-      /* Looking for lock_type components.  */
+-      if ((c->ts.type == BT_DERIVED
+-	      && c->ts.u.derived->from_intmod == INTMOD_ISO_FORTRAN_ENV
+-	      && c->ts.u.derived->intmod_sym_id == ISOFORTRAN_LOCK_TYPE)
+-	  || (c->ts.type == BT_CLASS && c->attr.class_ok
+-	      && CLASS_DATA (c)->ts.u.derived->from_intmod
+-		 == INTMOD_ISO_FORTRAN_ENV
+-	      && CLASS_DATA (c)->ts.u.derived->intmod_sym_id
+-		 == ISOFORTRAN_LOCK_TYPE)
+-	  || (c->ts.type == BT_DERIVED && c->ts.u.derived->attr.lock_comp
+-	      && !allocatable && !pointer))
+-	{
+-	  lock_type = 1;
+-	  lock_comp = c;
+-	  sym->attr.lock_comp = 1;
+-	}
+-
+-      /* Check for F2008, C1302 - and recall that pointers may not be coarrays
+-	 (5.3.14) and that subobjects of coarray are coarray themselves (2.4.7),
+-	 unless there are nondirect [allocatable or pointer] components
+-	 involved (cf. 1.3.33.1 and 1.3.33.3).  */
+-
+-      if (pointer && !coarray && lock_type)
+-	gfc_error ("Component %s at %L of type LOCK_TYPE must have a "
+-		   "codimension or be a subcomponent of a coarray, "
+-		   "which is not possible as the component has the "
+-		   "pointer attribute", c->name, &c->loc);
+-      else if (pointer && !coarray && c->ts.type == BT_DERIVED
+-	       && c->ts.u.derived->attr.lock_comp)
+-	gfc_error ("Pointer component %s at %L has a noncoarray subcomponent "
+-		   "of type LOCK_TYPE, which must have a codimension or be a "
+-		   "subcomponent of a coarray", c->name, &c->loc);
+-
+-      if (lock_type && allocatable && !coarray)
+-	gfc_error ("Allocatable component %s at %L of type LOCK_TYPE must have "
+-		   "a codimension", c->name, &c->loc);
+-      else if (lock_type && allocatable && c->ts.type == BT_DERIVED
+-	       && c->ts.u.derived->attr.lock_comp)
+-	gfc_error ("Allocatable component %s at %L must have a codimension as "
+-		   "it has a noncoarray subcomponent of type LOCK_TYPE",
+-		   c->name, &c->loc);
+-
+-      if (sym->attr.coarray_comp && !coarray && lock_type)
+-	gfc_error ("Noncoarray component %s at %L of type LOCK_TYPE or with "
+-		   "subcomponent of type LOCK_TYPE must have a codimension or "
+-		   "be a subcomponent of a coarray. (Variables of type %s may "
+-		   "not have a codimension as already a coarray "
+-		   "subcomponent exists)", c->name, &c->loc, sym->name);
+-
+-      if (sym->attr.lock_comp && coarray && !lock_type)
+-	gfc_error_1 ("Noncoarray component %s at %L of type LOCK_TYPE or with "
+-		   "subcomponent of type LOCK_TYPE must have a codimension or "
+-		   "be a subcomponent of a coarray. (Variables of type %s may "
+-		   "not have a codimension as %s at %L has a codimension or a "
+-		   "coarray subcomponent)", lock_comp->name, &lock_comp->loc,
+-		   sym->name, c->name, &c->loc);
+-
+-      /* Look for private components.  */
+-      if (sym->component_access == ACCESS_PRIVATE
+-	  || c->attr.access == ACCESS_PRIVATE
+-	  || (c->ts.type == BT_DERIVED && c->ts.u.derived->attr.private_comp))
+-	sym->attr.private_comp = 1;
+-    }
+-
+-  if (!seen_component)
+-    sym->attr.zero_comp = 1;
++  sym->attr.zero_comp = !seen_component;
+ 
+   pop_state ();
+ }
+@@ -3237,6 +3559,7 @@ loop:
+     case ST_PARAMETER:
+     case ST_PUBLIC:
+     case ST_PRIVATE:
++    case ST_STRUCTURE_DECL:
+     case ST_DERIVED_DECL:
+     case_decl:
+ declSt:
+@@ -3253,6 +3576,10 @@ declSt:
+ 	  parse_interface ();
+ 	  break;
+ 
++        case ST_STRUCTURE_DECL:
++          parse_structure ();
++          break;
++
+ 	case ST_DERIVED_DECL:
+ 	  parse_derived ();
+ 	  break;
+@@ -3512,6 +3839,13 @@ parse_if_block (void)
+   d = add_statement ();
+ 
+   d->expr1 = top->expr1;
++
++  if (gfc_option.allow_std & GFC_STD_EXTRA_LEGACY && top->expr1->ts.type != BT_LOGICAL)
++    {
++      d->expr1 = gfc_ne (top->expr1, gfc_get_int_expr (1, &gfc_current_locus, 0), INTRINSIC_NE);
++      gfc_warning_now (0, "The type of condition in this IF statement isn't LOGICAL; it will be true if it evaluates to nonzero.");
++    }
++
+   top->expr1 = NULL;
+   top->block = d;
+ 
+@@ -4766,9 +5100,9 @@ gfc_fixup_sibling_symbols (gfc_symbol *sym, gfc_namespace *siblings)
+       if (!st || (st->n.sym->attr.dummy && ns == st->n.sym->ns))
+ 	goto fixup_contained;
+ 
+-      if ((st->n.sym->attr.flavor == FL_DERIVED
++      if ((gfc_fl_struct (st->n.sym->attr.flavor)
+ 	   && sym->attr.generic && sym->attr.function)
+-	  ||(sym->attr.flavor == FL_DERIVED
++	  ||(gfc_fl_struct (sym->attr.flavor)
+ 	     && st->n.sym->attr.generic && st->n.sym->attr.function))
+ 	goto fixup_contained;
+ 
+diff --git a/gcc/fortran/parse.h b/gcc/fortran/parse.h
+index 8a1613f..1509417 100644
+--- a/gcc/fortran/parse.h
++++ b/gcc/fortran/parse.h
+@@ -27,6 +27,7 @@ typedef enum
+ {
+   COMP_NONE, COMP_PROGRAM, COMP_MODULE, COMP_SUBROUTINE, COMP_FUNCTION,
+   COMP_BLOCK_DATA, COMP_INTERFACE, COMP_DERIVED, COMP_DERIVED_CONTAINS,
++  COMP_STRUCTURE, COMP_UNION, COMP_MAP,
+   COMP_BLOCK, COMP_ASSOCIATE, COMP_IF,
+   COMP_DO, COMP_SELECT, COMP_FORALL, COMP_WHERE, COMP_CONTAINS, COMP_ENUM,
+   COMP_SELECT_TYPE, COMP_OMP_STRUCTURED_BLOCK, COMP_CRITICAL, COMP_DO_CONCURRENT
+@@ -60,10 +61,15 @@ extern gfc_state_data *gfc_state_stack;
+ #define gfc_current_block() (gfc_state_stack->sym)
+ #define gfc_current_state() (gfc_state_stack->state)
+ 
++/* STRUCTURE and TYPE are treated similarly, so these are common checks. */
++#define gfc_comp_is_derived(s) \
++    (((s) == COMP_DERIVED) || ((s) == COMP_STRUCTURE) || ((s) == COMP_MAP))
++
+ int gfc_check_do_variable (gfc_symtree *);
+ bool gfc_find_state (gfc_compile_state);
+ gfc_state_data *gfc_enclosing_unit (gfc_compile_state *);
+ const char *gfc_ascii_statement (gfc_statement);
++const char *gfc_ascii_comp_state (gfc_compile_state);
+ match gfc_match_enum (void);
+ match gfc_match_enumerator_def (void);
+ void gfc_free_enum_history (void);
+diff --git a/gcc/fortran/primary.c b/gcc/fortran/primary.c
+index e9ced7e..13e5cf4 100644
+--- a/gcc/fortran/primary.c
++++ b/gcc/fortran/primary.c
+@@ -1823,11 +1823,12 @@ gfc_match_varspec (gfc_expr *primary, int equiv_flag, bool sub_flag,
+ 		   bool ppc_arg)
+ {
+   char name[GFC_MAX_SYMBOL_LEN + 1];
+-  gfc_ref *substring, *tail;
++  gfc_ref *substring, *tail, *tmp;
+   gfc_component *component;
+   gfc_symbol *sym = primary->symtree->n.sym;
+   match m;
+   bool unknown;
++  char sep;
+ 
+   tail = NULL;
+ 
+@@ -1915,13 +1916,13 @@ gfc_match_varspec (gfc_expr *primary, int equiv_flag, bool sub_flag,
+       && gfc_get_default_type (sym->name, sym->ns)->type == BT_DERIVED)
+     gfc_set_default_type (sym, 0, sym->ns);
+ 
+-  if (sym->ts.type == BT_UNKNOWN && gfc_match_char ('%') == MATCH_YES)
++  if (sym->ts.type == BT_UNKNOWN && gfc_match_member_sep (sym) == MATCH_YES)
+     {
+       gfc_error ("Symbol %qs at %C has no IMPLICIT type", sym->name);
+       return MATCH_ERROR;
+     }
+   else if ((sym->ts.type != BT_DERIVED && sym->ts.type != BT_CLASS)
+-	   && gfc_match_char ('%') == MATCH_YES)
++	   && gfc_match_member_sep (sym) == MATCH_YES)
+     {
+       gfc_error ("Unexpected %<%%%> for nonderived-type variable %qs at %C",
+ 		 sym->name);
+@@ -1929,7 +1930,7 @@ gfc_match_varspec (gfc_expr *primary, int equiv_flag, bool sub_flag,
+     }
+ 
+   if ((sym->ts.type != BT_DERIVED && sym->ts.type != BT_CLASS)
+-      || gfc_match_char ('%') != MATCH_YES)
++      || gfc_match_member_sep (sym) != MATCH_YES)
+     goto check_substring;
+ 
+   sym = sym->ts.u.derived;
+@@ -2000,15 +2001,20 @@ gfc_match_varspec (gfc_expr *primary, int equiv_flag, bool sub_flag,
+ 	  break;
+ 	}
+ 
+-      component = gfc_find_component (sym, name, false, false);
++      component = gfc_find_component (sym, name, false, false, &tmp);
+       if (component == NULL)
+-	return MATCH_ERROR;
++        return MATCH_ERROR;
+ 
+-      tail = extend_ref (primary, tail);
+-      tail->type = REF_COMPONENT;
++      /* Extend the reference chain through the determined ref. */
++      if (primary->ref == NULL)
++        primary->ref = tmp;
++      else
++        tail->next = tmp;
+ 
+-      tail->u.c.component = component;
+-      tail->u.c.sym = sym;
++      /* The reference chain may be longer than one hop for union
++         subcomponents; find the new tail. */
++      for (tail = tmp; tail->next; tail = tail->next)
++        ;
+ 
+       primary->ts = component->ts;
+ 
+@@ -2058,7 +2064,7 @@ gfc_match_varspec (gfc_expr *primary, int equiv_flag, bool sub_flag,
+ 	}
+ 
+       if ((component->ts.type != BT_DERIVED && component->ts.type != BT_CLASS)
+-	  || gfc_match_char ('%') != MATCH_YES)
++	  || gfc_match_member_sep (component->ts.u.derived) != MATCH_YES)
+ 	break;
+ 
+       sym = component->ts.u.derived;
+@@ -2066,7 +2072,7 @@ gfc_match_varspec (gfc_expr *primary, int equiv_flag, bool sub_flag,
+ 
+ check_substring:
+   unknown = false;
+-  if (primary->ts.type == BT_UNKNOWN && sym->attr.flavor != FL_DERIVED)
++  if (primary->ts.type == BT_UNKNOWN && !gfc_fl_struct (sym->attr.flavor))
+     {
+       if (gfc_get_default_type (sym->name, sym->ns)->type == BT_CHARACTER)
+        {
+@@ -2499,11 +2505,11 @@ gfc_convert_to_structure_constructor (gfc_expr *e, gfc_symbol *sym, gfc_expr **c
+       /* Find the current component in the structure definition and check
+ 	     its access is not private.  */
+       if (comp)
+-	this_comp = gfc_find_component (sym, comp->name, false, false);
++	this_comp = gfc_find_component (sym, comp->name, false, false, NULL);
+       else
+ 	{
+ 	  this_comp = gfc_find_component (sym, (const char *)comp_tail->name,
+-					  false, false);
++					  false, false, NULL);
+ 	  comp = NULL; /* Reset needed!  */
+ 	}
+ 
+@@ -2547,7 +2553,7 @@ gfc_convert_to_structure_constructor (gfc_expr *e, gfc_symbol *sym, gfc_expr **c
+           if (comp && comp == sym->components
+                 && sym->attr.extension
+ 		&& comp_tail->val
+-                && (comp_tail->val->ts.type != BT_DERIVED
++                && (!gfc_bt_struct (comp_tail->val->ts.type)
+                       ||
+                     comp_tail->val->ts.u.derived != this_comp->ts.u.derived))
+             {
+@@ -2648,7 +2654,7 @@ gfc_match_structure_constructor (gfc_symbol *sym, gfc_expr **result)
+   e->symtree = symtree;
+   e->expr_type = EXPR_FUNCTION;
+ 
+-  gcc_assert (sym->attr.flavor == FL_DERIVED
++  gcc_assert (gfc_fl_struct (sym->attr.flavor)
+ 	      && symtree->n.sym->attr.flavor == FL_PROCEDURE);
+   e->value.function.esym = sym;
+   e->symtree->n.sym->attr.generic = 1;
+@@ -2736,6 +2742,15 @@ gfc_match_rvalue (gfc_expr **result)
+   bool implicit_char;
+   gfc_ref *ref;
+ 
++  m = MATCH_NO;
++  if (gfc_option.flag_loc_rval)
++    {
++      /* Let %LOC() act as a valid rvalue; treat it like GFC_ISYM_LOC */
++      m = gfc_match ("%%loc");
++      if (m == MATCH_YES)
++	strcpy (name, "loc");
++    }
++
+   m = gfc_match_name (name);
+   if (m != MATCH_YES)
+     return m;
+@@ -2746,8 +2761,34 @@ gfc_match_rvalue (gfc_expr **result)
+   else
+     i = gfc_get_ha_sym_tree (name, &symtree);
+ 
++  if (m != MATCH_YES)
++  {
++      m = gfc_match_name (name);
++      if (m != MATCH_YES)
++        return m;
++  }
++
++  /* Check if the symbol exists first */
++  i = gfc_find_sym_tree (name, NULL, 1, &symtree);
+   if (i)
+     return MATCH_ERROR;
++  /* If not, we do not create it if there is a corresponding structure decl */
++  if (!symtree)
++  {
++    i = gfc_find_sym_tree (gfc_dt_upper_string (name), NULL, 1, &symtree);
++    if (i)
++      return MATCH_ERROR;
++  }
++  if (!symtree || symtree->n.sym->attr.flavor != FL_STRUCT)
++  {
++    if (gfc_find_state (COMP_INTERFACE)
++        && !gfc_current_ns->has_import_set)
++      i = gfc_get_sym_tree (name, NULL, &symtree, false);
++    else
++      i = gfc_get_ha_sym_tree (name, &symtree);
++    if (i)
++      return MATCH_ERROR;
++  }
+ 
+   sym = symtree->n.sym;
+   e = NULL;
+@@ -2859,6 +2900,7 @@ gfc_match_rvalue (gfc_expr **result)
+ 
+       break;
+ 
++    case FL_STRUCT:
+     case FL_DERIVED:
+       sym = gfc_use_derived (sym);
+       if (sym == NULL)
+@@ -2999,6 +3041,7 @@ gfc_match_rvalue (gfc_expr **result)
+ 	 resolution phase.  */
+ 
+       if (gfc_peek_ascii_char () == '%'
++	  //if (gfc_match_member_sep (sym) == MATCH_YES // What is 'sym' here?
+ 	  && sym->ts.type == BT_UNKNOWN
+ 	  && gfc_get_default_type (sym->name, sym->ns)->type == BT_DERIVED)
+ 	gfc_set_default_type (sym, 0, sym->ns);
+@@ -3154,13 +3197,17 @@ gfc_match_rvalue (gfc_expr **result)
+       break;
+ 
+     generic_function:
+-      gfc_get_sym_tree (name, NULL, &symtree, false);	/* Can't fail */
++      gfc_find_sym_tree (name, NULL, 1, &symtree);
++      if (!symtree)
++        gfc_find_sym_tree (gfc_dt_upper_string (name), NULL, 1, &symtree);
++      if (!symtree || symtree->n.sym->attr.flavor != FL_STRUCT)
++        gfc_get_sym_tree (name, NULL, &symtree, false); /* Can't fail */
+ 
+       e = gfc_get_expr ();
+       e->symtree = symtree;
+       e->expr_type = EXPR_FUNCTION;
+ 
+-      if (sym->attr.flavor == FL_DERIVED)
++      if (gfc_fl_struct (sym->attr.flavor))
+ 	{
+ 	  e->value.function.esym = sym;
+ 	  e->symtree->n.sym->attr.generic = 1;
+@@ -3200,10 +3247,10 @@ gfc_match_rvalue (gfc_expr **result)
+ static match
+ match_variable (gfc_expr **result, int equiv_flag, int host_flag)
+ {
+-  gfc_symbol *sym;
++  gfc_symbol *sym, *dt_sym;
+   gfc_symtree *st;
+   gfc_expr *expr;
+-  locus where;
++  locus where, old_loc;
+   match m;
+ 
+   /* Since nothing has any business being an lvalue in a module
+@@ -3233,6 +3280,17 @@ match_variable (gfc_expr **result, int equiv_flag, int host_flag)
+   sym->attr.implied_index = 0;
+ 
+   gfc_set_sym_referenced (sym);
++
++  /* Check for generic symbols representing derived or structure types. */
++  if (sym->attr.flavor == FL_PROCEDURE && sym->generic
++      && (dt_sym = gfc_find_dt_in_generic (sym)))
++  {
++    if (dt_sym->attr.flavor == FL_DERIVED)
++      gfc_error ("Derived type '%s' cannot be used as a variable at %C",
++                 sym->name);
++    return MATCH_ERROR;
++  }
++
+   switch (sym->attr.flavor)
+     {
+     case FL_VARIABLE:
+@@ -3319,7 +3377,8 @@ match_variable (gfc_expr **result, int equiv_flag, int host_flag)
+       else
+ 	implicit_ns = sym->ns;
+ 
+-      if (gfc_peek_ascii_char () == '%'
++      if (gfc_peek_ascii_char() == '%'
++	  //if (gfc_match_member_sep (sym) == MATCH_YES // gfc_match_member_sep doesn't peek
+ 	  && sym->ts.type == BT_UNKNOWN
+ 	  && gfc_get_default_type (sym->name, implicit_ns)->type == BT_DERIVED)
+ 	gfc_set_default_type (sym, 0, implicit_ns);
+diff --git a/gcc/fortran/resolve.c b/gcc/fortran/resolve.c
+index da9d825..16ecf6c 100644
+--- a/gcc/fortran/resolve.c
++++ b/gcc/fortran/resolve.c
+@@ -537,7 +537,7 @@ static void
+ find_arglists (gfc_symbol *sym)
+ {
+   if (sym->attr.if_source == IFSRC_UNKNOWN || sym->ns != gfc_current_ns
+-      || sym->attr.flavor == FL_DERIVED || sym->attr.intrinsic)
++      || gfc_fl_struct (sym->attr.flavor)  || sym->attr.intrinsic)
+     return;
+ 
+   resolve_formal_arglist (sym);
+@@ -940,10 +940,20 @@ resolve_common_vars (gfc_symbol *sym, bool named_common)
+ 	continue;
+ 
+       if (!(csym->ts.u.derived->attr.sequence
+-	    || csym->ts.u.derived->attr.is_bind_c))
+-	gfc_error_now ("Derived type variable %qs in COMMON at %L "
+-		       "has neither the SEQUENCE nor the BIND(C) "
+-		       "attribute", csym->name, &csym->declared_at);
++	    || csym->ts.u.derived->attr.is_bind_c)) {
++	if (gfc_option.allow_std & GFC_STD_EXTRA_LEGACY)
++	  {
++	    /* Assume sequence. */
++	    csym->ts.u.derived->attr.sequence = 1;
++	  }
++	else
++	  {
++	    gfc_error_now ("Derived type variable '%s' in COMMON at %L "
++			   "has neither the SEQUENCE nor the BIND(C) "
++			   "attribute", csym->name, &csym->declared_at);
++	  }
++      }
++
+       if (csym->ts.u.derived->attr.alloc_comp)
+ 	gfc_error_now ("Derived type variable %qs in COMMON at %L "
+ 		       "has an ultimate component that is "
+@@ -1112,7 +1122,7 @@ resolve_contained_functions (gfc_namespace *ns)
+ 
+ 
+ static bool resolve_fl_derived0 (gfc_symbol *sym);
+-
++static bool resolve_fl_union (gfc_symbol *sym);
+ 
+ /* Resolve all of the elements of a structure constructor and make sure that
+    the types are correct. The 'init' flag indicates that the given
+@@ -1130,9 +1140,36 @@ resolve_structure_cons (gfc_expr *expr, int init)
+ 
+   if (expr->ts.type == BT_DERIVED)
+     resolve_fl_derived0 (expr->ts.u.derived);
++  else if (expr->ts.type == BT_UNION)
++    resolve_fl_union (expr->ts.u.derived);
+ 
+   cons = gfc_constructor_first (expr->value.constructor);
+ 
++  /* See if the user is trying to invoke a structure constructor for one of
++     the iso_c_binding derived types.  */
++  /* DISABLED TEMPORARILY - this is not present in GCC6 master, so I don't
++     believe it's necessary. */
++  /*
++  if (expr->ts.type == BT_DERIVED && expr->ts.u.derived
++      && expr->ts.u.derived->ts.is_iso_c && cons
++      && (cons->expr == NULL || cons->expr->expr_type != EXPR_NULL))
++    {
++      gfc_error ("Components of structure constructor '%s' at %L are PRIVATE",
++		 expr->ts.u.derived->name, &(expr->where));
++      return false;
++    }
++  */
++  
++  /* Return if structure constructor is c_null_(fun)prt.  */
++  if (expr->ts.type == BT_DERIVED && expr->ts.u.derived
++      && expr->ts.u.derived->ts.is_iso_c && cons
++      && cons->expr && cons->expr->expr_type == EXPR_NULL)
++    return true;
++
++  /* Union constructors only have one constructor. */
++  if (expr->ts.type == BT_UNION)
++    return true;
++
+   /* A constructor may have references if it is the result of substituting a
+      parameter variable.  In this case we just pull out the component we
+      want.  */
+@@ -1558,7 +1595,7 @@ is_illegal_recursion (gfc_symbol* sym, gfc_namespace* context)
+   gfc_namespace* real_context;
+ 
+   if (sym->attr.flavor == FL_PROGRAM
+-      || sym->attr.flavor == FL_DERIVED)
++      || gfc_fl_struct (sym->attr.flavor))
+     return false;
+ 
+   gcc_assert (sym->attr.flavor == FL_PROCEDURE);
+@@ -2545,7 +2582,7 @@ resolve_generic_f (gfc_expr *expr)
+ generic:
+       if (!intr)
+ 	for (intr = sym->generic; intr; intr = intr->next)
+-	  if (intr->sym->attr.flavor == FL_DERIVED)
++	  if (gfc_fl_struct (intr->sym->attr.flavor))
+ 	    break;
+ 
+       if (sym->ns->parent == NULL)
+@@ -3501,6 +3538,38 @@ compare_shapes (gfc_expr *op1, gfc_expr *op2)
+   return t;
+ }
+ 
++static int
++is_character_based (bt type)
++{
++  return type == BT_CHARACTER || type == BT_HOLLERITH;
++}
++
++static void
++convert_integer_to_logical (gfc_expr *e)
++{
++  if (e->ts.type == BT_INTEGER)
++    {
++      /* Convert to LOGICAL */
++      gfc_typespec t;
++      t.type = BT_LOGICAL;
++      t.kind = 1;
++      gfc_convert_type_warn (e, &t, 2, 1);
++    }
++}
++
++static void
++convert_logical_to_integer (gfc_expr *e)
++{
++  if (e->ts.type == BT_LOGICAL)
++    {
++      /* Convert to INTEGER */
++      gfc_typespec t;
++      t.type = BT_INTEGER;
++      t.kind = 1;
++      gfc_convert_type_warn (e, &t, 2, 1);
++    }
++}
++
+ 
+ /* Resolve an operator expression node.  This can involve replacing the
+    operation with a user defined function call.  */
+@@ -3596,6 +3665,11 @@ resolve_operator (gfc_expr *e)
+     case INTRINSIC_OR:
+     case INTRINSIC_EQV:
+     case INTRINSIC_NEQV:
++      if (gfc_option.allow_std & GFC_STD_EXTRA_LEGACY)
++	{
++	  convert_integer_to_logical(op1);
++	  convert_integer_to_logical(op2);
++	}
+       if (op1->ts.type == BT_LOGICAL && op2->ts.type == BT_LOGICAL)
+ 	{
+ 	  e->ts.type = BT_LOGICAL;
+@@ -3614,6 +3688,10 @@ resolve_operator (gfc_expr *e)
+       goto bad_op;
+ 
+     case INTRINSIC_NOT:
++      if (gfc_option.allow_std & GFC_STD_EXTRA_LEGACY)
++	{
++	  convert_integer_to_logical(op1);
++	}
+       if (op1->ts.type == BT_LOGICAL)
+ 	{
+ 	  e->ts.type = BT_LOGICAL;
+@@ -3645,6 +3723,38 @@ resolve_operator (gfc_expr *e)
+     case INTRINSIC_EQ_OS:
+     case INTRINSIC_NE:
+     case INTRINSIC_NE_OS:
++
++      if (gfc_option.allow_std & GFC_STD_EXTRA_LEGACY)
++	{
++	  convert_logical_to_integer(op1);
++	  convert_logical_to_integer(op2);
++	}
++
++      /* If you're comparing hollerith contants to character expresisons,
++	 convert the hollerith constant */
++      if (gfc_option.allow_std & GFC_STD_EXTRA_LEGACY &&
++	  is_character_based(op1->ts.type) && is_character_based(op2->ts.type)
++	  )
++	{
++	  gfc_typespec ts;
++	  ts.type = BT_CHARACTER;
++	  ts.kind = op1->ts.kind;
++	  if (op1->ts.type == BT_HOLLERITH)
++	    {
++	      gfc_convert_type_warn (op1, &ts, 2, 1);
++	      gfc_warning(0, "Promoting argument for comparison from HOLLERITH "
++		          "to CHARACTER at %L", &op1->where);
++	    }
++	  ts.type = BT_CHARACTER;
++	  ts.kind = op2->ts.kind;
++	  if (op2->ts.type == BT_HOLLERITH)
++	    {
++	      gfc_convert_type_warn (op2, &ts, 2, 1);
++	      gfc_warning(0, "Promoting argument for comparison from "
++			  "HOLLERITH to CHARACTER at %L", &op2->where);
++	    }
++	}
++
+       if (op1->ts.type == BT_CHARACTER && op2->ts.type == BT_CHARACTER
+ 	  && op1->ts.kind == op2->ts.kind)
+ 	{
+@@ -3653,6 +3763,25 @@ resolve_operator (gfc_expr *e)
+ 	  break;
+ 	}
+ 
++      /* Numeric to hollerith comparisons */
++      if(gfc_option.allow_std & GFC_STD_EXTRA_LEGACY && gfc_numeric_ts(&op1->ts) && (op2->ts.type == BT_HOLLERITH || op2->ts.type == BT_CHARACTER))
++	{
++	  gfc_warning(0, "Promoting argument for comparison from character type to INTEGER at %L", &op2->where);
++	  gfc_typespec ts;
++	  ts.type = BT_INTEGER;
++	  ts.kind = 4;
++	  gfc_convert_type_warn (op2, &ts, 2, 1);
++	}
++
++      if(gfc_option.allow_std & GFC_STD_EXTRA_LEGACY && gfc_numeric_ts(&op2->ts) && (op1->ts.type == BT_HOLLERITH || op1->ts.type == BT_CHARACTER))
++	{
++	  gfc_warning(0, "Promoting argument for comparison from character type to INTEGER at %L", &op1->where);
++	  gfc_typespec ts;
++	  ts.type = BT_INTEGER;
++	  ts.kind = 4;
++	  gfc_convert_type_warn (op1, &ts, 2, 1);
++	}
++
+       if (gfc_numeric_ts (&op1->ts) && gfc_numeric_ts (&op2->ts))
+ 	{
+ 	  gfc_type_convert_binary (e, 1);
+@@ -4147,6 +4276,26 @@ compare_spec_to_ref (gfc_array_ref *ar)
+   if (ar->type == AR_FULL)
+     return true;
+ 
++  if (gfc_option.allow_std & GFC_STD_EXTRA_LEGACY && as->rank > ar->dimen)
++    {
++      /* Add in the missing dimensions, assuming they are the lower bound
++         of that dimension if not specified. */
++      int j;
++      gfc_warning (0, "Using the lower bound for unspecified dimensions "
++                   "in array reference at %L", &ar->where);
++      /* Other parts of the code iterate ar->start and ar->end from 0 to
++	 ar->dimen, so it is safe to assume slots from ar->dimen upwards
++	 are unused (i.e. there are no gaps; the specified indexes are
++	 contiguous and start at zero */
++      for(j = ar->dimen; j <= as->rank; j++)
++        {
++	  ar->start[j] = gfc_copy_expr (as->lower[j]);
++	  ar->end[j]   = gfc_copy_expr (as->lower[j]);
++	  ar->dimen_type[j] = DIMEN_ELEMENT;
++        }
++      ar->dimen = as->rank;
++    }
++
+   if (as->rank != ar->dimen)
+     {
+       gfc_error ("Rank mismatch in array reference at %L (%d/%d)",
+@@ -4465,6 +4614,17 @@ resolve_substring (gfc_ref *ref)
+       if (!gfc_resolve_expr (ref->u.ss.start))
+ 	return false;
+ 
++      /* In legacy mode, allow non-integer string indexes by converting */
++      if (ref->u.ss.start->ts.type != BT_INTEGER &&
++	  gfc_numeric_ts (&ref->u.ss.start->ts) &&
++	  gfc_option.allow_std & GFC_STD_EXTRA_LEGACY)
++	{
++	  gfc_typespec t;
++	  t.type = BT_INTEGER;
++	  t.kind = ref->u.ss.start->ts.kind;
++	  gfc_convert_type_warn (ref->u.ss.start, &t, 2, 1);
++	}
++
+       if (ref->u.ss.start->ts.type != BT_INTEGER)
+ 	{
+ 	  gfc_error ("Substring start index at %L must be of type INTEGER",
+@@ -4494,6 +4654,17 @@ resolve_substring (gfc_ref *ref)
+       if (!gfc_resolve_expr (ref->u.ss.end))
+ 	return false;
+ 
++      /* Non-integer string index endings, as for start */
++      if (ref->u.ss.end->ts.type != BT_INTEGER &&
++	  gfc_numeric_ts (&ref->u.ss.end->ts) &&
++	  gfc_option.allow_std & GFC_STD_EXTRA_LEGACY)
++	{
++	  gfc_typespec t;
++	  t.type = BT_INTEGER;
++	  t.kind = ref->u.ss.end->ts.kind;
++	  gfc_convert_type_warn (ref->u.ss.end, &t, 2, 1);
++	}
++
+       if (ref->u.ss.end->ts.type != BT_INTEGER)
+ 	{
+ 	  gfc_error ("Substring end index at %L must be of type INTEGER",
+@@ -5625,7 +5796,7 @@ get_declared_from_expr (gfc_ref **class_ref, gfc_ref **new_ref,
+ 	continue;
+ 
+       if ((ref->u.c.component->ts.type == BT_CLASS
+-	     || (check_types && ref->u.c.component->ts.type == BT_DERIVED))
++	     || (check_types && gfc_bt_struct (ref->u.c.component->ts.type)))
+ 	  && ref->u.c.component->attr.flavor != FL_PROCEDURE)
+ 	{
+ 	  declared = ref->u.c.component->ts.u.derived;
+@@ -5701,7 +5872,7 @@ resolve_typebound_generic_call (gfc_expr* e, const char **name)
+ 				  && gfc_sym_get_dummy_args (target) == NULL);
+ 
+ 	  /* Check if this arglist matches the formal.  */
+-	  matches = gfc_arglist_matches_symbol (&args, target);
++	  matches = gfc_arglist_matches_symbol (&args, target, MATCH_EXACT);
+ 
+ 	  /* Clean up and break out of the loop if we've found it.  */
+ 	  gfc_free_actual_arglist (args);
+@@ -5888,7 +6059,7 @@ resolve_typebound_function (gfc_expr* e)
+ 	 is present.  */
+       ts = expr->ts;
+       declared = ts.u.derived;
+-      c = gfc_find_component (declared, "_vptr", true, true);
++      c = gfc_find_component (declared, "_vptr", true, true, NULL);
+       if (c->ts.u.derived == NULL)
+ 	c->ts.u.derived = gfc_find_derived_vtab (declared);
+ 
+@@ -5935,14 +6106,14 @@ resolve_typebound_function (gfc_expr* e)
+     return false;
+ 
+   /* Weed out cases of the ultimate component being a derived type.  */
+-  if ((class_ref && class_ref->u.c.component->ts.type == BT_DERIVED)
++  if ((class_ref && gfc_bt_struct (class_ref->u.c.component->ts.type))
+ 	 || (!class_ref && st->n.sym->ts.type != BT_CLASS))
+     {
+       gfc_free_ref_list (new_ref);
+       return resolve_compcall (e, NULL);
+     }
+ 
+-  c = gfc_find_component (declared, "_data", true, true);
++  c = gfc_find_component (declared, "_data", true, true, NULL);
+   declared = c->ts.u.derived;
+ 
+   /* Treat the call as if it is a typebound procedure, in order to roll
+@@ -6021,7 +6192,7 @@ resolve_typebound_subroutine (gfc_code *code)
+ 	 that any delays in resolution are corrected and that the vtab
+ 	 is present.  */
+       declared = expr->ts.u.derived;
+-      c = gfc_find_component (declared, "_vptr", true, true);
++      c = gfc_find_component (declared, "_vptr", true, true, NULL);
+       if (c->ts.u.derived == NULL)
+ 	c->ts.u.derived = gfc_find_derived_vtab (declared);
+ 
+@@ -6066,7 +6237,7 @@ resolve_typebound_subroutine (gfc_code *code)
+   get_declared_from_expr (&class_ref, &new_ref, code->expr1, true);
+ 
+   /* Weed out cases of the ultimate component being a derived type.  */
+-  if ((class_ref && class_ref->u.c.component->ts.type == BT_DERIVED)
++  if ((class_ref && gfc_bt_struct (class_ref->u.c.component->ts.type))
+ 	 || (!class_ref && st->n.sym->ts.type != BT_CLASS))
+     {
+       gfc_free_ref_list (new_ref);
+@@ -7020,7 +7191,7 @@ resolve_allocate_expr (gfc_expr *e, gfc_code *code)
+ 	 using _copy and trans_call. It is convenient to exploit that
+ 	 when the allocated type is different from the declared type but
+ 	 no SOURCE exists by setting expr3.  */
+-      code->expr3 = gfc_default_initializer (&code->ext.alloc.ts);
++      code->expr3 = gfc_default_initializer (&code->ext.alloc.ts, false);
+     }
+   else if (!code->expr3)
+     {
+@@ -7028,7 +7199,7 @@ resolve_allocate_expr (gfc_expr *e, gfc_code *code)
+       gfc_typespec ts;
+       gfc_expr *init_e;
+ 
+-      if (code->ext.alloc.ts.type == BT_DERIVED)
++      if (gfc_bt_struct (code->ext.alloc.ts.type))
+ 	ts = code->ext.alloc.ts;
+       else
+ 	ts = e->ts;
+@@ -7036,7 +7207,8 @@ resolve_allocate_expr (gfc_expr *e, gfc_code *code)
+       if (ts.type == BT_CLASS)
+ 	ts = ts.u.derived->components->ts;
+ 
+-      if (ts.type == BT_DERIVED && (init_e = gfc_default_initializer (&ts)))
++      if (gfc_bt_struct (ts.type) && (init_e = gfc_default_initializer (&ts,
++                                                                        false)))
+ 	{
+ 	  gfc_code *init_st = gfc_get_code (EXEC_INIT_ASSIGN);
+ 	  init_st->loc = code->loc;
+@@ -7049,7 +7221,7 @@ resolve_allocate_expr (gfc_expr *e, gfc_code *code)
+   else if (code->expr3->mold && code->expr3->ts.type == BT_DERIVED)
+     {
+       /* Default initialization via MOLD (non-polymorphic).  */
+-      gfc_expr *rhs = gfc_default_initializer (&code->expr3->ts);
++	gfc_expr *rhs = gfc_default_initializer (&code->expr3->ts, false);
+       if (rhs != NULL)
+ 	{
+ 	  gfc_resolve_expr (rhs);
+@@ -7151,7 +7323,7 @@ check_symbols:
+ 	  sym = a->expr->symtree->n.sym;
+ 
+ 	  /* TODO - check derived type components.  */
+-	  if (sym->ts.type == BT_DERIVED || sym->ts.type == BT_CLASS)
++	  if (gfc_bt_struct (sym->ts.type) || sym->ts.type == BT_CLASS)
+ 	    continue;
+ 
+ 	  if ((ar->start[i] != NULL
+@@ -9669,7 +9841,7 @@ nonscalar_typebound_assign (gfc_symbol *derived, int depth)
+ 
+   for (c= derived->components; c; c = c->next)
+     {
+-      if ((c->ts.type != BT_DERIVED
++      if ((!gfc_bt_struct (c->ts.type)
+ 	    || c->attr.pointer
+ 	    || c->attr.allocatable
+ 	    || c->attr.proc_pointer_comp
+@@ -9743,9 +9915,168 @@ static int component_assignment_level = 0;
+ static gfc_code *tmp_head = NULL, *tmp_tail = NULL;
+ 
+ static void
++generate_derived_component_assignments (gfc_code **code, gfc_namespace *ns,
++    gfc_code *this_code, gfc_code **head, gfc_code **tail, gfc_expr **t1,
++    gfc_symbol *d1, gfc_symbol *d2)
++{
++  gfc_component *comp1, *comp2, *map1, *map2;
++
++  comp1 = d1->components;
++  comp2 = d2->components;
++
++  for (; comp1; comp1 = comp1->next, comp2 = comp2->next)
++  {
++    bool inout = false;
++
++    /* For unions, just recurse into the maps. */
++    if (comp1->ts.type == BT_UNION)
++    {
++      map1 = comp1->ts.u.derived->components;
++      map2 = comp2->ts.u.derived->components;
++      for (; map1; map1 = map1->next, map2 = map2->next)
++      {
++        generate_derived_component_assignments (code, ns,
++            this_code, head, tail, t1, map1->ts.u.derived, map2->ts.u.derived);
++      }
++      continue;
++    }
++
++    /* The intrinsic assignment does the right thing for pointers
++       of all kinds and allocatable components.  */
++    if (comp1->ts.type != BT_DERIVED
++        || comp1->attr.pointer
++        || comp1->attr.allocatable
++        || comp1->attr.proc_pointer_comp
++        || comp1->attr.class_pointer
++        || comp1->attr.proc_pointer)
++      continue;
++
++    /* Make an assigment for this component.  */
++    this_code = build_assignment (EXEC_ASSIGN,
++                                  (*code)->expr1, (*code)->expr2,
++                                  comp1, comp2, (*code)->loc);
++
++    /* Convert the assignment if there is a defined assignment for
++       this type.  Otherwise, using the call from resolve_code,
++       recurse into its components.  */
++    gfc_resolve_code (this_code, ns);
++
++    if ((this_code)->op == EXEC_ASSIGN_CALL)
++      {
++        gfc_formal_arglist *dummy_args;
++        gfc_symbol *rsym;
++        /* Check that there is a typebound defined assignment.  If not,
++           then this must be a module defined assignment.  We cannot
++           use the defined_assign_comp attribute here because it must
++           be this derived type that has the defined assignment and not
++           a parent type.  */
++        if (!(comp1->ts.u.derived->f2k_derived
++              && comp1->ts.u.derived->f2k_derived
++                                      ->tb_op[INTRINSIC_ASSIGN]))
++          {
++            gfc_free_statements (this_code);
++            this_code = NULL;
++            continue;
++          }
++
++        /* If the first argument of the subroutine has intent INOUT
++           a temporary must be generated and used instead.  */
++        rsym = (this_code)->resolved_sym;
++        dummy_args = gfc_sym_get_dummy_args (rsym);
++        if (dummy_args
++            && dummy_args->sym->attr.intent == INTENT_INOUT)
++          {
++            gfc_code *temp_code;
++            inout = true;
++
++            /* Build the temporary required for the assignment and put
++               it at the head of the generated code.  */
++            if (!*t1)
++              {
++                *t1 = get_temp_from_expr ((*code)->expr1, ns);
++                temp_code = build_assignment (EXEC_ASSIGN,
++                                              *t1, (*code)->expr1,
++                              NULL, NULL, (*code)->loc);
++
++                /* For allocatable LHS, check whether it is allocated.  Note
++                   that allocatable components with defined assignment are
++                   not yet support.  See PR 57696.  */
++                if ((*code)->expr1->symtree->n.sym->attr.allocatable)
++                  {
++                    gfc_code *block;
++                    gfc_expr *e =
++                      gfc_lval_expr_from_sym ((*code)->expr1->symtree->n.sym);
++                    block = gfc_get_code (EXEC_IF);
++                    block->block = gfc_get_code (EXEC_IF);
++                    block->block->expr1
++                        = gfc_build_intrinsic_call (ns,
++                                  GFC_ISYM_ALLOCATED, "allocated",
++                                  (*code)->loc, 1, e);
++                    block->block->next = temp_code;
++                    temp_code = block;
++                  }
++                add_code_to_chain (&temp_code, &tmp_head, &tmp_tail);
++              }
++
++            /* Replace the first actual arg with the component of the
++               temporary.  */
++            gfc_free_expr ((this_code)->ext.actual->expr);
++            (this_code)->ext.actual->expr = gfc_copy_expr (*t1);
++            add_comp_ref ((this_code)->ext.actual->expr, comp1);
++
++            /* If the LHS variable is allocatable and wasn't allocated and
++               the temporary is allocatable, pointer assign the address of
++               the freshly allocated LHS to the temporary.  */
++            if ((*code)->expr1->symtree->n.sym->attr.allocatable
++                && gfc_expr_attr ((*code)->expr1).allocatable)
++              {
++                gfc_code *block;
++                gfc_expr *cond;
++
++                cond = gfc_get_expr ();
++                cond->ts.type = BT_LOGICAL;
++                cond->ts.kind = gfc_default_logical_kind;
++                cond->expr_type = EXPR_OP;
++                cond->where = (*code)->loc;
++                cond->value.op.op = INTRINSIC_NOT;
++                cond->value.op.op1 = gfc_build_intrinsic_call (ns,
++                                        GFC_ISYM_ALLOCATED, "allocated",
++                                        (*code)->loc, 1, gfc_copy_expr (*t1));
++                block = gfc_get_code (EXEC_IF);
++                block->block = gfc_get_code (EXEC_IF);
++                block->block->expr1 = cond;
++                block->block->next = build_assignment (EXEC_POINTER_ASSIGN,
++                                      *t1, (*code)->expr1,
++                                      NULL, NULL, (*code)->loc);
++                add_code_to_chain (&block, head, tail);
++              }
++          }
++      }
++    else if ((this_code)->op == EXEC_ASSIGN && !(this_code)->next)
++      {
++        /* Don't add intrinsic assignments since they are already
++           effected by the intrinsic assignment of the structure.  */
++        gfc_free_statements (this_code);
++        (this_code) = NULL;
++        continue;
++      }
++
++    add_code_to_chain (&this_code, head, tail);
++
++    if (*t1 && inout)
++      {
++        /* Transfer the value to the final result.  */
++        this_code = build_assignment (EXEC_ASSIGN,
++                                      (*code)->expr1, *t1,
++                                      comp1, comp2, (*code)->loc);
++        add_code_to_chain (&this_code, head, tail);
++      }
++  }
++}
++
++static void
+ generate_component_assignments (gfc_code **code, gfc_namespace *ns)
+ {
+-  gfc_component *comp1, *comp2;
+   gfc_code *this_code = NULL, *head = NULL, *tail = NULL;
+   gfc_expr *t1;
+   int error_count, depth;
+@@ -9799,145 +10130,11 @@ generate_component_assignments (gfc_code **code, gfc_namespace *ns)
+       add_code_to_chain (&this_code, &head, &tail);
+     }
+ 
+-  comp1 = (*code)->expr1->ts.u.derived->components;
+-  comp2 = (*code)->expr2->ts.u.derived->components;
+-
+   t1 = NULL;
+-  for (; comp1; comp1 = comp1->next, comp2 = comp2->next)
+-    {
+-      bool inout = false;
+ 
+-      /* The intrinsic assignment does the right thing for pointers
+-	 of all kinds and allocatable components.  */
+-      if (comp1->ts.type != BT_DERIVED
+-	  || comp1->attr.pointer
+-	  || comp1->attr.allocatable
+-	  || comp1->attr.proc_pointer_comp
+-	  || comp1->attr.class_pointer
+-	  || comp1->attr.proc_pointer)
+-	continue;
+-
+-      /* Make an assigment for this component.  */
+-      this_code = build_assignment (EXEC_ASSIGN,
+-				    (*code)->expr1, (*code)->expr2,
+-				    comp1, comp2, (*code)->loc);
+-
+-      /* Convert the assignment if there is a defined assignment for
+-	 this type.  Otherwise, using the call from gfc_resolve_code,
+-	 recurse into its components.  */
+-      gfc_resolve_code (this_code, ns);
+-
+-      if (this_code->op == EXEC_ASSIGN_CALL)
+-	{
+-	  gfc_formal_arglist *dummy_args;
+-	  gfc_symbol *rsym;
+-	  /* Check that there is a typebound defined assignment.  If not,
+-	     then this must be a module defined assignment.  We cannot
+-	     use the defined_assign_comp attribute here because it must
+-	     be this derived type that has the defined assignment and not
+-	     a parent type.  */
+-	  if (!(comp1->ts.u.derived->f2k_derived
+-		&& comp1->ts.u.derived->f2k_derived
+-					->tb_op[INTRINSIC_ASSIGN]))
+-	    {
+-	      gfc_free_statements (this_code);
+-	      this_code = NULL;
+-	      continue;
+-	    }
+-
+-	  /* If the first argument of the subroutine has intent INOUT
+-	     a temporary must be generated and used instead.  */
+-	  rsym = this_code->resolved_sym;
+-	  dummy_args = gfc_sym_get_dummy_args (rsym);
+-	  if (dummy_args
+-	      && dummy_args->sym->attr.intent == INTENT_INOUT)
+-	    {
+-	      gfc_code *temp_code;
+-	      inout = true;
+-
+-	      /* Build the temporary required for the assignment and put
+-		 it at the head of the generated code.  */
+-	      if (!t1)
+-		{
+-		  t1 = get_temp_from_expr ((*code)->expr1, ns);
+-		  temp_code = build_assignment (EXEC_ASSIGN,
+-						t1, (*code)->expr1,
+-				NULL, NULL, (*code)->loc);
+-
+-		  /* For allocatable LHS, check whether it is allocated.  Note
+-		     that allocatable components with defined assignment are
+-		     not yet support.  See PR 57696.  */
+-		  if ((*code)->expr1->symtree->n.sym->attr.allocatable)
+-		    {
+-		      gfc_code *block;
+-		      gfc_expr *e =
+-			gfc_lval_expr_from_sym ((*code)->expr1->symtree->n.sym);
+-		      block = gfc_get_code (EXEC_IF);
+-		      block->block = gfc_get_code (EXEC_IF);
+-		      block->block->expr1
+-			  = gfc_build_intrinsic_call (ns,
+-				    GFC_ISYM_ALLOCATED, "allocated",
+-				    (*code)->loc, 1, e);
+-		      block->block->next = temp_code;
+-		      temp_code = block;
+-		    }
+-		  add_code_to_chain (&temp_code, &tmp_head, &tmp_tail);
+-		}
+-
+-	      /* Replace the first actual arg with the component of the
+-		 temporary.  */
+-	      gfc_free_expr (this_code->ext.actual->expr);
+-	      this_code->ext.actual->expr = gfc_copy_expr (t1);
+-	      add_comp_ref (this_code->ext.actual->expr, comp1);
+-
+-	      /* If the LHS variable is allocatable and wasn't allocated and
+-                 the temporary is allocatable, pointer assign the address of
+-                 the freshly allocated LHS to the temporary.  */
+-	      if ((*code)->expr1->symtree->n.sym->attr.allocatable
+-		  && gfc_expr_attr ((*code)->expr1).allocatable)
+-		{
+-		  gfc_code *block;
+-		  gfc_expr *cond;
+-
+-		  cond = gfc_get_expr ();
+-		  cond->ts.type = BT_LOGICAL;
+-		  cond->ts.kind = gfc_default_logical_kind;
+-		  cond->expr_type = EXPR_OP;
+-		  cond->where = (*code)->loc;
+-		  cond->value.op.op = INTRINSIC_NOT;
+-		  cond->value.op.op1 = gfc_build_intrinsic_call (ns,
+-					  GFC_ISYM_ALLOCATED, "allocated",
+-					  (*code)->loc, 1, gfc_copy_expr (t1));
+-		  block = gfc_get_code (EXEC_IF);
+-		  block->block = gfc_get_code (EXEC_IF);
+-		  block->block->expr1 = cond;
+-		  block->block->next = build_assignment (EXEC_POINTER_ASSIGN,
+-					t1, (*code)->expr1,
+-					NULL, NULL, (*code)->loc);
+-		  add_code_to_chain (&block, &head, &tail);
+-		}
+-	    }
+-	}
+-      else if (this_code->op == EXEC_ASSIGN && !this_code->next)
+-	{
+-	  /* Don't add intrinsic assignments since they are already
+-	     effected by the intrinsic assignment of the structure.  */
+-	  gfc_free_statements (this_code);
+-	  this_code = NULL;
+-	  continue;
+-	}
+-
+-      add_code_to_chain (&this_code, &head, &tail);
+-
+-      if (t1 && inout)
+-	{
+-	  /* Transfer the value to the final result.  */
+-	  this_code = build_assignment (EXEC_ASSIGN,
+-					(*code)->expr1, t1,
+-					comp1, comp2, (*code)->loc);
+-	  add_code_to_chain (&this_code, &head, &tail);
+-	}
+-    }
++  generate_derived_component_assignments (code, ns,
++      this_code, &head, &tail, &t1,
++      (*code)->expr1->ts.u.derived, (*code)->expr2->ts.u.derived);
+ 
+   /* Put the temporary assignments at the top of the generated code.  */
+   if (tmp_head && component_assignment_level == 1)
+@@ -10483,7 +10680,7 @@ resolve_values (gfc_symbol *sym)
+ static void
+ resolve_bind_c_derived_types (gfc_symbol *derived_sym)
+ {
+-  if (derived_sym != NULL && derived_sym->attr.flavor == FL_DERIVED
++  if (derived_sym != NULL && gfc_fl_struct (derived_sym->attr.flavor)
+       && derived_sym->attr.is_bind_c == 1)
+     verify_bind_c_derived_type (derived_sym);
+ 
+@@ -10502,7 +10699,7 @@ gfc_verify_binding_labels (gfc_symbol *sym)
+   const char *module;
+ 
+   if (!sym || !sym->attr.is_bind_c || sym->attr.is_iso_c
+-      || sym->attr.flavor == FL_DERIVED || !sym->binding_label)
++      || gfc_fl_struct (sym->attr.flavor) || !sym->binding_label)
+     return;
+ 
+   gsym = gfc_find_gsymbol (gfc_gsym_root, sym->binding_label);
+@@ -10735,6 +10932,34 @@ build_init_assign (gfc_symbol *sym, gfc_expr *init)
+   init_st->expr2 = init;
+ }
+ 
++/* Whether or not we can create an initializer for the given symbol.  */
++
++static bool
++can_create_init (gfc_symbol *sym)
++{
++  symbol_attribute *a;
++  if (!sym)
++    return false;
++  a = &sym->attr;
++
++  /* These symbols should never have a default initialization.  */
++  return !(
++       a->allocatable
++    || a->external
++    || a->pointer
++    || a->in_equivalence
++    || a->in_common
++    || a->data
++    || sym->module
++    || a->cray_pointee
++    || a->cray_pointer
++    || sym->assoc
++    || (!a->referenced && !a->result)
++    || (a->dummy && a->intent != INTENT_OUT)
++    || (a->function && sym != sym->result)
++  );
++} 
++
+ /* Assign the default initializer to a derived type variable or result.  */
+ 
+ static void
+@@ -10746,7 +10971,7 @@ apply_default_init (gfc_symbol *sym)
+     return;
+ 
+   if (sym->ts.type == BT_DERIVED && sym->ts.u.derived)
+-    init = gfc_default_initializer (&sym->ts);
++    init = gfc_default_initializer (&sym->ts, can_create_init (sym));
+ 
+   if (init == NULL && sym->ts.type != BT_CLASS)
+     return;
+@@ -11069,7 +11294,7 @@ resolve_fl_variable_derived (gfc_symbol *sym, int no_init_flag)
+       gfc_find_symbol (sym->ts.u.derived->name, sym->ns, 0, &s);
+       if (s && s->attr.generic)
+ 	s = gfc_find_dt_in_generic (s);
+-      if (s && s->attr.flavor != FL_DERIVED)
++      if (s && !gfc_fl_struct (s->attr.flavor))
+ 	{
+ 	  gfc_error_1 ("The type '%s' cannot be host associated at %L "
+ 		     "because it is blocked by an incompatible object "
+@@ -11102,7 +11327,7 @@ resolve_fl_variable_derived (gfc_symbol *sym, int no_init_flag)
+   if (!(sym->value || sym->attr.pointer || sym->attr.allocatable)
+       && (!no_init_flag || sym->attr.intent == INTENT_OUT))
+     {
+-      sym->value = gfc_default_initializer (&sym->ts);
++      sym->value = gfc_default_initializer (&sym->ts, can_create_init (sym));
+     }
+ 
+   return true;
+@@ -12272,7 +12497,8 @@ resolve_typebound_procedure (gfc_symtree* stree)
+       }
+ 
+   /* Try to find a name collision with an inherited component.  */
+-  if (super_type && gfc_find_component (super_type, stree->name, true, true))
++  if (super_type && gfc_find_component (super_type, stree->name, true, true,
++                                        NULL))
+     {
+       gfc_error ("Procedure %qs at %L has the same name as an inherited"
+ 		 " component of %qs",
+@@ -12420,7 +12646,7 @@ check_defined_assignments (gfc_symbol *derived)
+ 
+   for (c = derived->components; c; c = c->next)
+     {
+-      if (c->ts.type != BT_DERIVED
++      if (!gfc_bt_struct (c->ts.type)
+ 	  || c->attr.pointer
+ 	  || c->attr.allocatable
+ 	  || c->attr.proc_pointer_comp
+@@ -12446,432 +12672,472 @@ check_defined_assignments (gfc_symbol *derived)
+ }
+ 
+ 
+-/* Resolve the components of a derived type. This does not have to wait until
+-   resolution stage, but can be done as soon as the dt declaration has been
+-   parsed.  */
+ 
+-static bool
+-resolve_fl_derived0 (gfc_symbol *sym)
++const int SUCCESS = 0;
++const int FAIL_CONTINUE = 1;
++const int FAIL_STOP = 2;
++
++static int
++resolve_component (gfc_component *c, void *data)
+ {
+-  gfc_symbol* super_type;
+-  gfc_component *c;
++  gfc_symbol *sym = (gfc_symbol *)data;
++  gfc_symbol *super_type = gfc_get_derived_super_type (sym);
+ 
+-  if (sym->attr.unlimited_polymorphic)
+-    return true;
++  if (c->attr.artificial)
++    return SUCCESS;
+ 
+-  super_type = gfc_get_derived_super_type (sym);
+-
+-  /* F2008, C432.  */
+-  if (super_type && sym->attr.coarray_comp && !super_type->attr.coarray_comp)
++  /* F2008, C442.  */
++  if ((!sym->attr.is_class || c != sym->components)
++      && c->attr.codimension
++      && (!c->attr.allocatable || (c->as && c->as->type != AS_DEFERRED)))
+     {
+-      gfc_error ("As extending type %qs at %L has a coarray component, "
+-		 "parent type %qs shall also have one", sym->name,
+-		 &sym->declared_at, super_type->name);
+-      return false;
++      gfc_error ("Coarray component %qs at %L must be allocatable with "
++		 "deferred shape", c->name, &c->loc);
++      return FAIL_CONTINUE;
+     }
+ 
+-  /* Ensure the extended type gets resolved before we do.  */
+-  if (super_type && !resolve_fl_derived0 (super_type))
+-    return false;
+-
+-  /* An ABSTRACT type must be extensible.  */
+-  if (sym->attr.abstract && !gfc_type_is_extensible (sym))
++  /* F2008, C443.  */
++  if (c->attr.codimension && c->ts.type == BT_DERIVED
++      && c->ts.u.derived->ts.is_iso_c)
+     {
+-      gfc_error ("Non-extensible derived-type %qs at %L must not be ABSTRACT",
+-		 sym->name, &sym->declared_at);
+-      return false;
++      gfc_error ("Component %qs at %L of TYPE(C_PTR) or TYPE(C_FUNPTR) "
++		 "shall not be a coarray", c->name, &c->loc);
++      return FAIL_CONTINUE;
+     }
+ 
+-  c = (sym->attr.is_class) ? sym->components->ts.u.derived->components
+-			   : sym->components;
+-
+-  bool success = true;
+-
+-  for ( ; c != NULL; c = c->next)
++  /* F2008, C444.  */
++  if (c->ts.type == BT_DERIVED && c->ts.u.derived->attr.coarray_comp
++      && (c->attr.codimension || c->attr.pointer || c->attr.dimension
++	  || c->attr.allocatable))
+     {
+-      if (c->attr.artificial)
+-	continue;
+-
+-      /* F2008, C442.  */
+-      if ((!sym->attr.is_class || c != sym->components)
+-	  && c->attr.codimension
+-	  && (!c->attr.allocatable || (c->as && c->as->type != AS_DEFERRED)))
+-	{
+-	  gfc_error ("Coarray component %qs at %L must be allocatable with "
+-		     "deferred shape", c->name, &c->loc);
+-	  success = false;
+-	  continue;
+-	}
++      gfc_error ("Component %qs at %L with coarray component "
++		 "shall be a nonpointer, nonallocatable scalar",
++		 c->name, &c->loc);
++      return FAIL_CONTINUE;
++    }
+ 
+-      /* F2008, C443.  */
+-      if (c->attr.codimension && c->ts.type == BT_DERIVED
+-	  && c->ts.u.derived->ts.is_iso_c)
+-	{
+-	  gfc_error ("Component %qs at %L of TYPE(C_PTR) or TYPE(C_FUNPTR) "
+-		     "shall not be a coarray", c->name, &c->loc);
+-	  success = false;
+-	  continue;
+-	}
++  /* F2008, C448.  */
++  if (c->attr.contiguous && (!c->attr.dimension || !c->attr.pointer))
++    {
++      gfc_error ("Component %qs at %L has the CONTIGUOUS attribute but "
++		 "is not an array pointer", c->name, &c->loc);
++      return FAIL_CONTINUE;
++    }
+ 
+-      /* F2008, C444.  */
+-      if (c->ts.type == BT_DERIVED && c->ts.u.derived->attr.coarray_comp
+-	  && (c->attr.codimension || c->attr.pointer || c->attr.dimension
+-	      || c->attr.allocatable))
+-	{
+-	  gfc_error ("Component %qs at %L with coarray component "
+-		     "shall be a nonpointer, nonallocatable scalar",
+-		     c->name, &c->loc);
+-	  success = false;
+-	  continue;
+-	}
++  if (c->attr.proc_pointer && c->ts.interface)
++    {
++      gfc_symbol *ifc = c->ts.interface;
+ 
+-      /* F2008, C448.  */
+-      if (c->attr.contiguous && (!c->attr.dimension || !c->attr.pointer))
++      if (!sym->attr.vtype && !check_proc_interface (ifc, &c->loc))
+ 	{
+-	  gfc_error ("Component %qs at %L has the CONTIGUOUS attribute but "
+-		     "is not an array pointer", c->name, &c->loc);
+-	  success = false;
+-	  continue;
++	  c->tb->error = 1;
++	  return FAIL_CONTINUE;
+ 	}
+ 
+-      if (c->attr.proc_pointer && c->ts.interface)
++      if (ifc->attr.if_source || ifc->attr.intrinsic)
+ 	{
+-	  gfc_symbol *ifc = c->ts.interface;
++	  /* Resolve interface and copy attributes.  */
++	  if (ifc->formal && !ifc->formal_ns)
++	    resolve_symbol (ifc);
++	  if (ifc->attr.intrinsic)
++	    gfc_resolve_intrinsic (ifc, &ifc->declared_at);
+ 
+-	  if (!sym->attr.vtype && !check_proc_interface (ifc, &c->loc))
++	  if (ifc->result)
+ 	    {
+-	      c->tb->error = 1;
+-	      success = false;
+-	      continue;
++	      c->ts = ifc->result->ts;
++	      c->attr.allocatable = ifc->result->attr.allocatable;
++	      c->attr.pointer = ifc->result->attr.pointer;
++	      c->attr.dimension = ifc->result->attr.dimension;
++	      c->as = gfc_copy_array_spec (ifc->result->as);
++	      c->attr.class_ok = ifc->result->attr.class_ok;
+ 	    }
+-
+-	  if (ifc->attr.if_source || ifc->attr.intrinsic)
++	  else
+ 	    {
+-	      /* Resolve interface and copy attributes.  */
+-	      if (ifc->formal && !ifc->formal_ns)
+-		resolve_symbol (ifc);
+-	      if (ifc->attr.intrinsic)
+-		gfc_resolve_intrinsic (ifc, &ifc->declared_at);
+-
+-	      if (ifc->result)
+-		{
+-		  c->ts = ifc->result->ts;
+-		  c->attr.allocatable = ifc->result->attr.allocatable;
+-		  c->attr.pointer = ifc->result->attr.pointer;
+-		  c->attr.dimension = ifc->result->attr.dimension;
+-		  c->as = gfc_copy_array_spec (ifc->result->as);
+-		  c->attr.class_ok = ifc->result->attr.class_ok;
+-		}
+-	      else
+-		{
+-		  c->ts = ifc->ts;
+-		  c->attr.allocatable = ifc->attr.allocatable;
+-		  c->attr.pointer = ifc->attr.pointer;
+-		  c->attr.dimension = ifc->attr.dimension;
+-		  c->as = gfc_copy_array_spec (ifc->as);
+-		  c->attr.class_ok = ifc->attr.class_ok;
+-		}
+-	      c->ts.interface = ifc;
+-	      c->attr.function = ifc->attr.function;
+-	      c->attr.subroutine = ifc->attr.subroutine;
+-
+-	      c->attr.pure = ifc->attr.pure;
+-	      c->attr.elemental = ifc->attr.elemental;
+-	      c->attr.recursive = ifc->attr.recursive;
+-	      c->attr.always_explicit = ifc->attr.always_explicit;
+-	      c->attr.ext_attr |= ifc->attr.ext_attr;
+-	      /* Copy char length.  */
+-	      if (ifc->ts.type == BT_CHARACTER && ifc->ts.u.cl)
++	      c->ts = ifc->ts;
++	      c->attr.allocatable = ifc->attr.allocatable;
++	      c->attr.pointer = ifc->attr.pointer;
++	      c->attr.dimension = ifc->attr.dimension;
++	      c->as = gfc_copy_array_spec (ifc->as);
++	      c->attr.class_ok = ifc->attr.class_ok;
++	    }
++	  c->ts.interface = ifc;
++	  c->attr.function = ifc->attr.function;
++	  c->attr.subroutine = ifc->attr.subroutine;
++
++	  c->attr.pure = ifc->attr.pure;
++	  c->attr.elemental = ifc->attr.elemental;
++	  c->attr.recursive = ifc->attr.recursive;
++	  c->attr.always_explicit = ifc->attr.always_explicit;
++	  c->attr.ext_attr |= ifc->attr.ext_attr;
++	  /* Copy char length.  */
++	  if (ifc->ts.type == BT_CHARACTER && ifc->ts.u.cl)
++	    {
++	      gfc_charlen *cl = gfc_new_charlen (sym->ns, ifc->ts.u.cl);
++	      if (cl->length && !cl->resolved
++		  && !gfc_resolve_expr (cl->length))
+ 		{
+-		  gfc_charlen *cl = gfc_new_charlen (sym->ns, ifc->ts.u.cl);
+-		  if (cl->length && !cl->resolved
+-		      && !gfc_resolve_expr (cl->length))
+-		    {
+-		      c->tb->error = 1;
+-		      success = false;
+-		      continue;
+-		    }
+-		  c->ts.u.cl = cl;
++		  c->tb->error = 1;
++		  return FAIL_CONTINUE;
+ 		}
++	      c->ts.u.cl = cl;
+ 	    }
+ 	}
+-      else if (c->attr.proc_pointer && c->ts.type == BT_UNKNOWN)
+-	{
+-	  /* Since PPCs are not implicitly typed, a PPC without an explicit
+-	     interface must be a subroutine.  */
+-	  gfc_add_subroutine (&c->attr, c->name, &c->loc);
+-	}
+-
+-      /* Procedure pointer components: Check PASS arg.  */
+-      if (c->attr.proc_pointer && !c->tb->nopass && c->tb->pass_arg_num == 0
+-	  && !sym->attr.vtype)
+-	{
+-	  gfc_symbol* me_arg;
++    }
++  else if (c->attr.proc_pointer && c->ts.type == BT_UNKNOWN)
++    {
++      /* Since PPCs are not implicitly typed, a PPC without an explicit
++	 interface must be a subroutine.  */
++      gfc_add_subroutine (&c->attr, c->name, &c->loc);
++    }
+ 
+-	  if (c->tb->pass_arg)
+-	    {
+-	      gfc_formal_arglist* i;
++  /* Procedure pointer components: Check PASS arg.  */
++  if (c->attr.proc_pointer && !c->tb->nopass && c->tb->pass_arg_num == 0
++      && !sym->attr.vtype)
++    {
++      gfc_symbol* me_arg;
+ 
+-	      /* If an explicit passing argument name is given, walk the arg-list
+-		and look for it.  */
++      if (c->tb->pass_arg)
++	{
++	  gfc_formal_arglist* i;
+ 
+-	      me_arg = NULL;
+-	      c->tb->pass_arg_num = 1;
+-	      for (i = c->ts.interface->formal; i; i = i->next)
+-		{
+-		  if (!strcmp (i->sym->name, c->tb->pass_arg))
+-		    {
+-		      me_arg = i->sym;
+-		      break;
+-		    }
+-		  c->tb->pass_arg_num++;
+-		}
++	  /* If an explicit passing argument name is given, walk the arg-list
++	     and look for it.  */
+ 
+-	      if (!me_arg)
+-		{
+-		  gfc_error ("Procedure pointer component %qs with PASS(%s) "
+-			     "at %L has no argument %qs", c->name,
+-			     c->tb->pass_arg, &c->loc, c->tb->pass_arg);
+-		  c->tb->error = 1;
+-		  success = false;
+-		  continue;
+-		}
+-	    }
+-	  else
++	  me_arg = NULL;
++	  c->tb->pass_arg_num = 1;
++	  for (i = c->ts.interface->formal; i; i = i->next)
+ 	    {
+-	      /* Otherwise, take the first one; there should in fact be at least
+-		one.  */
+-	      c->tb->pass_arg_num = 1;
+-	      if (!c->ts.interface->formal)
++	      if (!strcmp (i->sym->name, c->tb->pass_arg))
+ 		{
+-		  gfc_error ("Procedure pointer component %qs with PASS at %L "
+-			     "must have at least one argument",
+-			     c->name, &c->loc);
+-		  c->tb->error = 1;
+-		  success = false;
+-		  continue;
++		  me_arg = i->sym;
++		  break;
+ 		}
+-	      me_arg = c->ts.interface->formal->sym;
+-	    }
+-
+-	  /* Now check that the argument-type matches.  */
+-	  gcc_assert (me_arg);
+-	  if ((me_arg->ts.type != BT_DERIVED && me_arg->ts.type != BT_CLASS)
+-	      || (me_arg->ts.type == BT_DERIVED && me_arg->ts.u.derived != sym)
+-	      || (me_arg->ts.type == BT_CLASS
+-		  && CLASS_DATA (me_arg)->ts.u.derived != sym))
+-	    {
+-	      gfc_error ("Argument %qs of %qs with PASS(%s) at %L must be of"
+-			 " the derived type %qs", me_arg->name, c->name,
+-			 me_arg->name, &c->loc, sym->name);
+-	      c->tb->error = 1;
+-	      success = false;
+-	      continue;
+-	    }
+-
+-	  /* Check for C453.  */
+-	  if (me_arg->attr.dimension)
+-	    {
+-	      gfc_error ("Argument %qs of %qs with PASS(%s) at %L "
+-			 "must be scalar", me_arg->name, c->name, me_arg->name,
+-			 &c->loc);
+-	      c->tb->error = 1;
+-	      success = false;
+-	      continue;
++	      c->tb->pass_arg_num++;
+ 	    }
+ 
+-	  if (me_arg->attr.pointer)
++	  if (!me_arg)
+ 	    {
+-	      gfc_error ("Argument %qs of %qs with PASS(%s) at %L "
+-			 "may not have the POINTER attribute", me_arg->name,
+-			 c->name, me_arg->name, &c->loc);
++	      gfc_error ("Procedure pointer component %qs with PASS(%s) "
++			 "at %L has no argument %qs", c->name,
++			 c->tb->pass_arg, &c->loc, c->tb->pass_arg);
+ 	      c->tb->error = 1;
+-	      success = false;
+-	      continue;
++	      return FAIL_CONTINUE;
+ 	    }
+-
+-	  if (me_arg->attr.allocatable)
++	}
++      else
++	{
++	  /* Otherwise, take the first one; there should in fact be at least
++	     one.  */
++	  c->tb->pass_arg_num = 1;
++	  if (!c->ts.interface->formal)
+ 	    {
+-	      gfc_error ("Argument %qs of %qs with PASS(%s) at %L "
+-			 "may not be ALLOCATABLE", me_arg->name, c->name,
+-			 me_arg->name, &c->loc);
++	      gfc_error ("Procedure pointer component %qs with PASS at %L "
++			 "must have at least one argument",
++			 c->name, &c->loc);
+ 	      c->tb->error = 1;
+-	      success = false;
+-	      continue;
++	      return FAIL_CONTINUE;
+ 	    }
+-
+-	  if (gfc_type_is_extensible (sym) && me_arg->ts.type != BT_CLASS)
+-	    {
+-	      gfc_error ("Non-polymorphic passed-object dummy argument of %qs"
+-			 " at %L", c->name, &c->loc);
+-	      success = false;
+-	      continue;
+-	    }
+-
++	  me_arg = c->ts.interface->formal->sym;
+ 	}
+ 
+-      /* Check type-spec if this is not the parent-type component.  */
+-      if (((sym->attr.is_class
+-	    && (!sym->components->ts.u.derived->attr.extension
+-		|| c != sym->components->ts.u.derived->components))
+-	   || (!sym->attr.is_class
+-	       && (!sym->attr.extension || c != sym->components)))
+-	  && !sym->attr.vtype
+-	  && !resolve_typespec_used (&c->ts, &c->loc, c->name))
+-	return false;
+-
+-      /* If this type is an extension, set the accessibility of the parent
+-	 component.  */
+-      if (super_type
+-	  && ((sym->attr.is_class
+-	       && c == sym->components->ts.u.derived->components)
+-	      || (!sym->attr.is_class && c == sym->components))
+-	  && strcmp (super_type->name, c->name) == 0)
+-	c->attr.access = super_type->attr.access;
+-
+-      /* If this type is an extension, see if this component has the same name
+-	 as an inherited type-bound procedure.  */
+-      if (super_type && !sym->attr.is_class
+-	  && gfc_find_typebound_proc (super_type, NULL, c->name, true, NULL))
+-	{
+-	  gfc_error ("Component %qs of %qs at %L has the same name as an"
+-		     " inherited type-bound procedure",
+-		     c->name, sym->name, &c->loc);
+-	  return false;
+-	}
+-
+-      if (c->ts.type == BT_CHARACTER && !c->attr.proc_pointer
+-	    && !c->ts.deferred)
++      /* Now check that the argument-type matches.  */
++      gcc_assert (me_arg);
++      if ((me_arg->ts.type != BT_DERIVED && me_arg->ts.type != BT_CLASS)
++	  || (me_arg->ts.type == BT_DERIVED && me_arg->ts.u.derived != sym)
++	  || (me_arg->ts.type == BT_CLASS
++	      && CLASS_DATA (me_arg)->ts.u.derived != sym))
+ 	{
+-	 if (c->ts.u.cl->length == NULL
+-	     || (!resolve_charlen(c->ts.u.cl))
+-	     || !gfc_is_constant_expr (c->ts.u.cl->length))
+-	   {
+-	     gfc_error ("Character length of component %qs needs to "
+-			"be a constant specification expression at %L",
+-			c->name,
+-			c->ts.u.cl->length ? &c->ts.u.cl->length->where : &c->loc);
+-	     return false;
+-	   }
++	  gfc_error ("Argument %qs of %qs with PASS(%s) at %L must be of"
++		     " the derived type %qs", me_arg->name, c->name,
++		     me_arg->name, &c->loc, sym->name);
++	  c->tb->error = 1;
++	  return FAIL_CONTINUE;
+ 	}
+ 
+-      if (c->ts.type == BT_CHARACTER && c->ts.deferred
+-	  && !c->attr.pointer && !c->attr.allocatable)
++      /* Check for C453.  */
++      if (me_arg->attr.dimension)
+ 	{
+-	  gfc_error ("Character component %qs of %qs at %L with deferred "
+-		     "length must be a POINTER or ALLOCATABLE",
+-		     c->name, sym->name, &c->loc);
+-	  return false;
++	  gfc_error ("Argument %qs of %qs with PASS(%s) at %L "
++		     "must be scalar", me_arg->name, c->name, me_arg->name,
++		     &c->loc);
++	  c->tb->error = 1;
++	  return FAIL_CONTINUE;
+ 	}
+ 
+-      /* Add the hidden deferred length field.  */
+-      if (c->ts.type == BT_CHARACTER && c->ts.deferred && !c->attr.function
+-	  && !sym->attr.is_class)
++      if (me_arg->attr.pointer)
+ 	{
+-	  char name[GFC_MAX_SYMBOL_LEN+9];
+-	  gfc_component *strlen;
+-	  sprintf (name, "_%s_length", c->name);
+-	  strlen = gfc_find_component (sym, name, true, true);
+-	  if (strlen == NULL)
+-	    {
+-	      if (!gfc_add_component (sym, name, &strlen))
+-		return false;
+-	      strlen->ts.type = BT_INTEGER;
+-	      strlen->ts.kind = gfc_charlen_int_kind;
+-	      strlen->attr.access = ACCESS_PRIVATE;
+-	      strlen->attr.artificial = 1;
+-	    }
++	  gfc_error ("Argument %qs of %qs with PASS(%s) at %L "
++		     "may not have the POINTER attribute", me_arg->name,
++		     c->name, me_arg->name, &c->loc);
++	  c->tb->error = 1;
++	  return FAIL_CONTINUE;
+ 	}
+ 
+-      if (c->ts.type == BT_DERIVED
+-	  && sym->component_access != ACCESS_PRIVATE
+-	  && gfc_check_symbol_access (sym)
+-	  && !is_sym_host_assoc (c->ts.u.derived, sym->ns)
+-	  && !c->ts.u.derived->attr.use_assoc
+-	  && !gfc_check_symbol_access (c->ts.u.derived)
+-	  && !gfc_notify_std (GFC_STD_F2003, "the component %qs is a "
+-			      "PRIVATE type and cannot be a component of "
+-			      "%qs, which is PUBLIC at %L", c->name,
+-			      sym->name, &sym->declared_at))
+-	return false;
+-
+-      if ((sym->attr.sequence || sym->attr.is_bind_c) && c->ts.type == BT_CLASS)
++      if (me_arg->attr.allocatable)
+ 	{
+-	  gfc_error ("Polymorphic component %s at %L in SEQUENCE or BIND(C) "
+-		     "type %s", c->name, &c->loc, sym->name);
+-	  return false;
++	  gfc_error ("Argument %qs of %qs with PASS(%s) at %L "
++		     "may not be ALLOCATABLE", me_arg->name, c->name,
++		     me_arg->name, &c->loc);
++	  c->tb->error = 1;
++	  return FAIL_CONTINUE;
+ 	}
+ 
+-      if (sym->attr.sequence)
++      if (gfc_type_is_extensible (sym) && me_arg->ts.type != BT_CLASS)
+ 	{
+-	  if (c->ts.type == BT_DERIVED && c->ts.u.derived->attr.sequence == 0)
+-	    {
+-	      gfc_error ("Component %s of SEQUENCE type declared at %L does "
+-			 "not have the SEQUENCE attribute",
+-			 c->ts.u.derived->name, &sym->declared_at);
+-	      return false;
+-	    }
++	  gfc_error ("Non-polymorphic passed-object dummy argument of %qs"
++		     " at %L", c->name, &c->loc);
++	  return FAIL_CONTINUE;
+ 	}
+ 
+-      if (c->ts.type == BT_DERIVED && c->ts.u.derived->attr.generic)
+-	c->ts.u.derived = gfc_find_dt_in_generic (c->ts.u.derived);
+-      else if (c->ts.type == BT_CLASS && c->attr.class_ok
+-	       && CLASS_DATA (c)->ts.u.derived->attr.generic)
+-	CLASS_DATA (c)->ts.u.derived
+-			= gfc_find_dt_in_generic (CLASS_DATA (c)->ts.u.derived);
++    }
++
++  /* Check type-spec if this is not the parent-type component.  */
++  if (((sym->attr.is_class
++	&& (!sym->components->ts.u.derived->attr.extension
++	    || c != sym->components->ts.u.derived->components))
++       || (!sym->attr.is_class
++	   && (!sym->attr.extension || c != sym->components)))
++      && !sym->attr.vtype
++      && !resolve_typespec_used (&c->ts, &c->loc, c->name))
++    return FAIL_STOP;
+ 
+-      if (!sym->attr.is_class && c->ts.type == BT_DERIVED && !sym->attr.vtype
+-	  && c->attr.pointer && c->ts.u.derived->components == NULL
+-	  && !c->ts.u.derived->attr.zero_comp)
++  /* If this type is an extension, set the accessibility of the parent
++     component.  */
++  if (super_type
++      && ((sym->attr.is_class
++	   && c == sym->components->ts.u.derived->components)
++	  || (!sym->attr.is_class && c == sym->components))
++      && strcmp (super_type->name, c->name) == 0)
++    c->attr.access = super_type->attr.access;
++
++  /* If this type is an extension, see if this component has the same name
++     as an inherited type-bound procedure.  */
++  if (super_type && !sym->attr.is_class
++      && gfc_find_typebound_proc (super_type, NULL, c->name, true, NULL))
++    {
++      gfc_error ("Component %qs of %qs at %L has the same name as an"
++		 " inherited type-bound procedure",
++		 c->name, sym->name, &c->loc);
++      return FAIL_STOP;
++    }
++
++  if (c->ts.type == BT_CHARACTER && !c->attr.proc_pointer
++      && !c->ts.deferred)
++    {
++      if (c->ts.u.cl->length == NULL
++	  || (!resolve_charlen(c->ts.u.cl))
++	  || !gfc_is_constant_expr (c->ts.u.cl->length))
+ 	{
+-	  gfc_error ("The pointer component %qs of %qs at %L is a type "
+-		     "that has not been declared", c->name, sym->name,
+-		     &c->loc);
+-	  return false;
++	  gfc_error ("Character length of component %qs needs to "
++		     "be a constant specification expression at %L",
++		     c->name,
++		     c->ts.u.cl->length ? &c->ts.u.cl->length->where : &c->loc);
++	  return FAIL_STOP;
+ 	}
++    }
+ 
+-      if (c->ts.type == BT_CLASS && c->attr.class_ok
+-	  && CLASS_DATA (c)->attr.class_pointer
+-	  && CLASS_DATA (c)->ts.u.derived->components == NULL
+-	  && !CLASS_DATA (c)->ts.u.derived->attr.zero_comp
+-	  && !UNLIMITED_POLY (c))
++  if (c->ts.type == BT_CHARACTER && c->ts.deferred
++      && !c->attr.pointer && !c->attr.allocatable)
++    {
++      gfc_error ("Character component %qs of %qs at %L with deferred "
++		 "length must be a POINTER or ALLOCATABLE",
++		 c->name, sym->name, &c->loc);
++      return FAIL_STOP;
++    }
++
++  /* Add the hidden deferred length field.  */
++  if (c->ts.type == BT_CHARACTER && c->ts.deferred && !c->attr.function
++      && !sym->attr.is_class)
++    {
++      char name[GFC_MAX_SYMBOL_LEN+9];
++      gfc_component *strlen;
++      sprintf (name, "_%s_length", c->name);
++      strlen = gfc_find_component (sym, name, true, true, NULL);
++      if (strlen == NULL)
+ 	{
+-	  gfc_error ("The pointer component %qs of %qs at %L is a type "
+-		     "that has not been declared", c->name, sym->name,
+-		     &c->loc);
+-	  return false;
++	  if (!gfc_add_component (sym, name, &strlen))
++	    return FAIL_STOP;
++	  strlen->ts.type = BT_INTEGER;
++	  strlen->ts.kind = gfc_charlen_int_kind;
++	  strlen->attr.access = ACCESS_PRIVATE;
++	  strlen->attr.artificial = 1;
+ 	}
++    }
++
++  if (c->ts.type == BT_DERIVED
++      && sym->component_access != ACCESS_PRIVATE
++      && gfc_check_symbol_access (sym)
++      && !is_sym_host_assoc (c->ts.u.derived, sym->ns)
++      && !c->ts.u.derived->attr.use_assoc
++      && !gfc_check_symbol_access (c->ts.u.derived)
++      && !gfc_notify_std (GFC_STD_F2003, "the component %qs is a "
++			  "PRIVATE type and cannot be a component of "
++			  "%qs, which is PUBLIC at %L", c->name,
++			  sym->name, &sym->declared_at))
++    return FAIL_STOP;
++
++  if ((sym->attr.sequence || sym->attr.is_bind_c) && c->ts.type == BT_CLASS)
++    {
++      gfc_error ("Polymorphic component %s at %L in SEQUENCE or BIND(C) "
++		 "type %s", c->name, &c->loc, sym->name);
++      return FAIL_STOP;
++    }
+ 
+-      /* C437.  */
+-      if (c->ts.type == BT_CLASS && c->attr.flavor != FL_PROCEDURE
+-	  && (!c->attr.class_ok
+-	      || !(CLASS_DATA (c)->attr.class_pointer
+-		   || CLASS_DATA (c)->attr.allocatable)))
++  if (sym->attr.sequence)
++    {
++      if (c->ts.type == BT_DERIVED && c->ts.u.derived->attr.sequence == 0)
+ 	{
+-	  gfc_error ("Component %qs with CLASS at %L must be allocatable "
+-		     "or pointer", c->name, &c->loc);
+-	  /* Prevent a recurrence of the error.  */
+-	  c->ts.type = BT_UNKNOWN;
+-	  return false;
++	  gfc_error ("Component %s of SEQUENCE type declared at %L does "
++		     "not have the SEQUENCE attribute",
++		     c->ts.u.derived->name, &sym->declared_at);
++	  return FAIL_STOP;
+ 	}
++    }
++
++  if (c->ts.type == BT_DERIVED && c->ts.u.derived->attr.generic)
++    c->ts.u.derived = gfc_find_dt_in_generic (c->ts.u.derived);
++  else if (c->ts.type == BT_CLASS && c->attr.class_ok
++	   && CLASS_DATA (c)->ts.u.derived->attr.generic)
++    CLASS_DATA (c)->ts.u.derived
++      = gfc_find_dt_in_generic (CLASS_DATA (c)->ts.u.derived);
++
++  if (!sym->attr.is_class && c->ts.type == BT_DERIVED && !sym->attr.vtype
++      && c->attr.pointer && c->ts.u.derived->components == NULL
++      && !c->ts.u.derived->attr.zero_comp)
++    {
++      gfc_error ("The pointer component %qs of %qs at %L is a type "
++		 "that has not been declared", c->name, sym->name,
++		 &c->loc);
++      return FAIL_STOP;
++    }
++
++  if (c->ts.type == BT_CLASS && c->attr.class_ok
++      && CLASS_DATA (c)->attr.class_pointer
++      && CLASS_DATA (c)->ts.u.derived->components == NULL
++      && !CLASS_DATA (c)->ts.u.derived->attr.zero_comp
++      && !UNLIMITED_POLY (c))
++    {
++      gfc_error ("The pointer component %qs of %qs at %L is a type "
++		 "that has not been declared", c->name, sym->name,
++		 &c->loc);
++      return FAIL_STOP;
++    }
++
++  /* C437.  */
++  if (c->ts.type == BT_CLASS && c->attr.flavor != FL_PROCEDURE
++      && (!c->attr.class_ok
++	  || !(CLASS_DATA (c)->attr.class_pointer
++	       || CLASS_DATA (c)->attr.allocatable)))
++    {
++      gfc_error ("Component %qs with CLASS at %L must be allocatable "
++		 "or pointer", c->name, &c->loc);
++      /* Prevent a recurrence of the error.  */
++      c->ts.type = BT_UNKNOWN;
++      return FAIL_STOP;
++    }
++
++  if (c->ts.type == BT_UNION && !resolve_fl_union (c->ts.u.derived))
++    return FAIL_CONTINUE;
++
++  /* Ensure that all the derived type components are put on the
++     derived type list; even in formal namespaces, where derived type
++     pointer components might not have been declared.  */
++  if (c->ts.type == BT_DERIVED
++      && c->ts.u.derived
++      && c->ts.u.derived->components
++      && c->attr.pointer
++      && sym != c->ts.u.derived)
++    add_dt_to_dt_list (c->ts.u.derived);
++
++  if (!gfc_resolve_array_spec (c->as,
++			       !(c->attr.pointer || c->attr.proc_pointer
++				 || c->attr.allocatable)))
++    return FAIL_STOP;
++
++  if (c->initializer && !sym->attr.vtype
++      && !gfc_check_assign_symbol (sym, c, c->initializer))
++    return FAIL_STOP;
+ 
+-      /* Ensure that all the derived type components are put on the
+-	 derived type list; even in formal namespaces, where derived type
+-	 pointer components might not have been declared.  */
+-      if (c->ts.type == BT_DERIVED
+-	    && c->ts.u.derived
+-	    && c->ts.u.derived->components
+-	    && c->attr.pointer
+-	    && sym != c->ts.u.derived)
+-	add_dt_to_dt_list (c->ts.u.derived);
++  return SUCCESS;
++
++}
++
++/* Resolve the components of a union type. */
++
++static bool
++resolve_fl_union (gfc_symbol *sym)
++{
++  gfc_component *map;
++  bool success;
+ 
+-      if (!gfc_resolve_array_spec (c->as,
+-				   !(c->attr.pointer || c->attr.proc_pointer
+-				     || c->attr.allocatable)))
++  gcc_assert (sym->attr.flavor == FL_UNION);
++
++  success = true;
++  for (map = sym->components; map; map = map->next)
++    {
++      int res = resolve_component (map, (void *)sym);
++      if (res == FAIL_CONTINUE)
++	success = false;
++      else if (res == FAIL_STOP)
+ 	return false;
++    }
++
++  if (success != SUCCESS)
++    return false;
++
++  if (sym->components)
++    add_dt_to_dt_list (sym);
+ 
+-      if (c->initializer && !sym->attr.vtype
+-	  && !gfc_check_assign_symbol (sym, c, c->initializer))
++  return true;
++}
++
++/* Resolve the components of a derived type. This does not have to wait until
++   resolution stage, but can be done as soon as the dt declaration has been
++   parsed.  */
++
++static bool
++resolve_fl_derived0 (gfc_symbol *sym)
++{
++  gfc_symbol* super_type;
++  gfc_component *c;
++
++  if (sym->attr.unlimited_polymorphic)
++    return true;
++
++  super_type = gfc_get_derived_super_type (sym);
++
++  /* F2008, C432.  */
++  if (super_type && sym->attr.coarray_comp && !super_type->attr.coarray_comp)
++    {
++      gfc_error ("As extending type %qs at %L has a coarray component, "
++		 "parent type %qs shall also have one", sym->name,
++		 &sym->declared_at, super_type->name);
++      return false;
++    }
++
++  /* Ensure the extended type gets resolved before we do.  */
++  if (super_type && !resolve_fl_derived0 (super_type))
++    return false;
++
++  /* An ABSTRACT type must be extensible.  */
++  if (sym->attr.abstract && !gfc_type_is_extensible (sym))
++    {
++      gfc_error ("Non-extensible derived-type %qs at %L must not be ABSTRACT",
++		 sym->name, &sym->declared_at);
++      return false;
++    }
++
++  c = (sym->attr.is_class) ? sym->components->ts.u.derived->components
++			   : sym->components;
++
++  bool success = true;
++
++  for ( ; c != NULL; c = c->next)
++    {
++      int res = resolve_component (c, (void *)sym);
++      if (res == FAIL_CONTINUE)
++	success = false;
++      else if (res == FAIL_STOP)
+ 	return false;
+     }
+ 
+@@ -12935,8 +13201,8 @@ resolve_fl_derived (gfc_symbol *sym)
+   if (sym->attr.is_class && sym->ts.u.derived == NULL)
+     {
+       /* Fix up incomplete CLASS symbols.  */
+-      gfc_component *data = gfc_find_component (sym, "_data", true, true);
+-      gfc_component *vptr = gfc_find_component (sym, "_vptr", true, true);
++      gfc_component *data = gfc_find_component (sym, "_data", true, true, NULL);
++      gfc_component *vptr = gfc_find_component (sym, "_vptr", true, true, NULL);
+ 
+       /* Nothing more to do for unlimited polymorphic entities.  */
+       if (data->ts.u.derived->attr.unlimited_polymorphic)
+@@ -13155,6 +13421,11 @@ resolve_symbol (gfc_symbol *sym)
+     return;
+   sym->resolved = 1;
+ 
++  /* No symbol will ever have union type; only components can be unions.
++     Union type declaration symbols have type BT_UNKNOWN but flavor FL_UNION
++     (just like derived type declaration symbols have flavor FL_DERIVED). */
++  gcc_assert (sym->ts.type != BT_UNION);
++
+   if (sym->attr.artificial)
+     return;
+ 
+@@ -13223,7 +13494,11 @@ resolve_symbol (gfc_symbol *sym)
+       return;
+     }
+ 
+-  if (sym->attr.flavor == FL_DERIVED && !resolve_fl_derived (sym))
++  if ((sym->attr.flavor == FL_DERIVED || sym->attr.flavor == FL_STRUCT)
++      && resolve_fl_derived (sym) == false)
++    return;
++
++  if (sym->attr.flavor == FL_UNION && resolve_fl_union (sym) == false)
+     return;
+ 
+   /* Symbols that are module procedures with results (functions) have
+@@ -13497,7 +13772,7 @@ resolve_symbol (gfc_symbol *sym)
+      interoperability when a variable is declared of that type.  */
+   if (sym->attr.is_bind_c && sym->attr.implicit_type == 0 &&
+       sym->attr.use_assoc == 0 && sym->attr.dummy == 0 &&
+-      sym->attr.flavor != FL_PROCEDURE && sym->attr.flavor != FL_DERIVED)
++      sym->attr.flavor != FL_PROCEDURE && !gfc_fl_struct (sym->attr.flavor))
+     {
+       bool t = true;
+ 
+@@ -14440,8 +14715,7 @@ sequence_type (gfc_typespec ts)
+ 
+   switch (ts.type)
+   {
+-    case BT_DERIVED:
+-
++    case_struct_bt:
+       if (ts.u.derived->components == NULL)
+ 	return SEQ_NONDEFAULT;
+ 
+@@ -14527,8 +14801,8 @@ resolve_equivalence_derived (gfc_symbol *derived, gfc_symbol *sym, gfc_expr *e)
+ 
+   for (; c ; c = c->next)
+     {
+-      if (c->ts.type == BT_DERIVED
+-	  && (!resolve_equivalence_derived(c->ts.u.derived, sym, e)))
++      if (gfc_bt_struct (c->ts.type)
++	  && (resolve_equivalence_derived (c->ts.u.derived, sym, e) == false))
+ 	return false;
+ 
+       /* Shall not be an object of sequence derived type containing a pointer
+diff --git a/gcc/fortran/simplify.c b/gcc/fortran/simplify.c
+index 20d50d2..efb8c81 100644
+--- a/gcc/fortran/simplify.c
++++ b/gcc/fortran/simplify.c
+@@ -2497,7 +2497,7 @@ gfc_simplify_iachar (gfc_expr *e, gfc_expr *kind)
+   if (e->expr_type != EXPR_CONSTANT)
+     return NULL;
+ 
+-  if (e->value.character.length != 1)
++  if (e->value.character.length != 1 && !(gfc_option.allow_std & GFC_STD_EXTRA_LEGACY))
+     {
+       gfc_error ("Argument of IACHAR at %L must be of length one", &e->where);
+       return &gfc_bad_expr;
+@@ -2695,7 +2695,7 @@ gfc_simplify_ichar (gfc_expr *e, gfc_expr *kind)
+   if (e->expr_type != EXPR_CONSTANT)
+     return NULL;
+ 
+-  if (e->value.character.length != 1)
++  if (e->value.character.length != 1 && !(gfc_option.allow_std & GFC_STD_EXTRA_LEGACY))
+     {
+       gfc_error ("Argument of ICHAR at %L must be of length one", &e->where);
+       return &gfc_bad_expr;
+@@ -6360,7 +6360,7 @@ gfc_simplify_transfer (gfc_expr *source, gfc_expr *mold, gfc_expr *size)
+   /* Allocate the buffer to store the binary version of the source.  */
+   buffer_size = MAX (source_size, result_size);
+   buffer = (unsigned char*)alloca (buffer_size);
+-  memset (buffer, 0, buffer_size);
++  memset (buffer, 0x20, buffer_size);
+ 
+   /* Now write source to the buffer.  */
+   gfc_target_encode_expr (source, buffer, buffer_size);
+@@ -6850,7 +6850,16 @@ gfc_convert_constant (gfc_expr *e, bt type, int kind)
+ 	  goto oops;
+ 	}
+       break;
+-
++    case BT_CHARACTER:
++      switch(type)
++	{
++	case BT_INTEGER:
++	  f = gfc_character2int;
++	  break;
++	default:
++	  goto oops;
++	}
++      break;
+     default:
+     oops:
+       gfc_internal_error ("gfc_convert_constant(): Unexpected type");
+diff --git a/gcc/fortran/symbol.c b/gcc/fortran/symbol.c
+index 8c43854..7e0e7f7 100644
+--- a/gcc/fortran/symbol.c
++++ b/gcc/fortran/symbol.c
+@@ -40,6 +40,7 @@ const mstring flavors[] =
+   minit ("VARIABLE", FL_VARIABLE), minit ("PARAMETER", FL_PARAMETER),
+   minit ("LABEL", FL_LABEL), minit ("PROCEDURE", FL_PROCEDURE),
+   minit ("DERIVED", FL_DERIVED), minit ("NAMELIST", FL_NAMELIST),
++  minit ("UNION", FL_UNION), minit ("STRUCTURE", FL_STRUCT),
+   minit (NULL, -1)
+ };
+ 
+@@ -356,9 +357,9 @@ gfc_check_function_type (gfc_namespace *ns)
+ static bool
+ check_conflict (symbol_attribute *attr, const char *name, locus *where)
+ {
+-  static const char *dummy = "DUMMY", *save = "SAVE", *pointer = "POINTER",
+-    *target = "TARGET", *external = "EXTERNAL", *intent = "INTENT",
+-    *intent_in = "INTENT(IN)", *intrinsic = "INTRINSIC",
++  static const char *dummy = "DUMMY", *save = "SAVE", *automatic = "AUTOMATIC",
++    *pointer = "POINTER", *target = "TARGET", *external = "EXTERNAL",
++    *intent = "INTENT", *intent_in = "INTENT(IN)", *intrinsic = "INTRINSIC",
+     *intent_out = "INTENT(OUT)", *intent_inout = "INTENT(INOUT)",
+     *allocatable = "ALLOCATABLE", *elemental = "ELEMENTAL",
+     *privat = "PRIVATE", *recursive = "RECURSIVE",
+@@ -427,6 +428,35 @@ check_conflict (symbol_attribute *attr, const char *name, locus *where)
+ 	}
+     }
+ 
++  if (attr->automatic)
++    {
++      conf (save, automatic);
++      conf (data, automatic);
++      conf (in_common, automatic);
++
++      switch (attr->flavor)
++	{
++	  case FL_PROGRAM:
++	  case FL_BLOCK_DATA:
++	  case FL_MODULE:
++	  case FL_LABEL:
++	  case FL_DERIVED:
++	  case FL_PARAMETER:
++            a1 = gfc_code2string (flavors, attr->flavor);
++            a2 = save;
++	    goto conflict;
++	  case FL_NAMELIST:
++	    gfc_error ("Namelist group name at %L cannot have the "
++		       "AUTOMATIC attribute", where);
++	    return false;
++	    break;
++	  case FL_PROCEDURE:
++	  case FL_VARIABLE:
++	  default:
++	    break;
++	}
++    }
++
+   if (attr->save == SAVE_EXPLICIT)
+     {
+       conf (dummy, save);
+@@ -439,8 +469,8 @@ check_conflict (symbol_attribute *attr, const char *name, locus *where)
+ 	  case FL_BLOCK_DATA:
+ 	  case FL_MODULE:
+ 	  case FL_LABEL:
+-	  case FL_DERIVED:
+ 	  case FL_PARAMETER:
++          case_struct_fl:
+             a1 = gfc_code2string (flavors, attr->flavor);
+             a2 = save;
+ 	    goto conflict;
+@@ -719,7 +749,7 @@ check_conflict (symbol_attribute *attr, const char *name, locus *where)
+ 
+       break;
+ 
+-    case FL_DERIVED:
++    case_struct_fl:
+       conf2 (dummy);
+       conf2 (pointer);
+       conf2 (target);
+@@ -1150,6 +1180,21 @@ gfc_add_save (symbol_attribute *attr, save_state s, const char *name,
+   return check_conflict (attr, name, where);
+ }
+ 
++bool
++gfc_add_automatic (symbol_attribute *attr,  const char *name, locus *where)
++{
++
++  if (check_used (attr, name, where))
++    return false;
++
++  if (!gfc_notify_std (GFC_STD_LEGACY,
++		      "AUTOMATIC attribute specified at %L",
++		       where))
++    return false;
++
++  attr->automatic = 1;
++  return check_conflict (attr, name, where);
++}
+ 
+ bool
+ gfc_add_value (symbol_attribute *attr, const char *name, locus *where)
+@@ -1494,7 +1539,7 @@ gfc_add_flavor (symbol_attribute *attr, sym_flavor f, const char *name,
+ {
+ 
+   if ((f == FL_PROGRAM || f == FL_BLOCK_DATA || f == FL_MODULE
+-       || f == FL_PARAMETER || f == FL_LABEL || f == FL_DERIVED
++       || f == FL_PARAMETER || f == FL_LABEL || gfc_fl_struct (f)
+        || f == FL_NAMELIST) && check_used (attr, name, where))
+     return false;
+ 
+@@ -1703,6 +1748,8 @@ gfc_add_type (gfc_symbol *sym, gfc_typespec *ts, locus *where)
+   if (sym->attr.result && type == BT_UNKNOWN && sym->ns->proc_name)
+     type = sym->ns->proc_name->ts.type;
+ 
++  flavor = sym->attr.flavor;
++
+   if (type != BT_UNKNOWN && !(sym->attr.function && sym->attr.implicit_type))
+     {
+       if (sym->attr.use_assoc)
+@@ -1710,8 +1757,23 @@ gfc_add_type (gfc_symbol *sym, gfc_typespec *ts, locus *where)
+ 		   "use-associated at %L", sym->name, where, sym->module,
+ 		   &sym->declared_at);
+       else
+-	gfc_error ("Symbol %qs at %L already has basic type of %s", sym->name,
+-		 where, gfc_basic_typename (type));
++	{
++          if (sym->ts.type == BT_DERIVED || sym->ts.type == BT_CLASS || sym->ts.type == BT_PROCEDURE) {
++	    /* Ignore temporaries and class/procedure names */
++	    return false;
++	  }
++	  if (gfc_compare_types(&sym->ts, ts) && (flavor == FL_UNKNOWN || flavor == FL_VARIABLE || (flavor == FL_PROCEDURE && gfc_option.allow_std & GFC_STD_EXTRA_LEGACY)))
++	    {
++	      return gfc_notify_std (GFC_STD_LEGACY,
++				     "Symbol '%s' at %L already has basic type of %s", sym->name,
++				     where, gfc_basic_typename (type));
++	    }
++	  else
++	    {
++	      gfc_error ("Symbol '%s' at %L already has basic type of %s", sym->name,
++			 where, gfc_basic_typename (type));
++	    }
++	}
+       return false;
+     }
+ 
+@@ -1722,12 +1784,10 @@ gfc_add_type (gfc_symbol *sym, gfc_typespec *ts, locus *where)
+       return false;
+     }
+ 
+-  flavor = sym->attr.flavor;
+-
+   if (flavor == FL_PROGRAM || flavor == FL_BLOCK_DATA || flavor == FL_MODULE
+       || flavor == FL_LABEL
+       || (flavor == FL_PROCEDURE && sym->attr.subroutine)
+-      || flavor == FL_DERIVED || flavor == FL_NAMELIST)
++      || gfc_fl_struct (flavor) || flavor == FL_NAMELIST)
+     {
+       gfc_error ("Symbol %qs at %L cannot have a type", sym->name, where);
+       return false;
+@@ -1791,6 +1851,8 @@ gfc_copy_attr (symbol_attribute *dest, symbol_attribute *src, locus *where)
+     goto fail;
+   if (src->value && !gfc_add_value (dest, NULL, where))
+     goto fail;
++  if (src->automatic && !gfc_add_automatic (dest, NULL, where))
++    goto fail;
+   if (src->volatile_ && !gfc_add_volatile (dest, NULL, where))
+     goto fail;
+   if (src->asynchronous && !gfc_add_asynchronous (dest, NULL, where))
+@@ -1894,6 +1956,11 @@ gfc_add_component (gfc_symbol *sym, const char *name,
+ {
+   gfc_component *p, *tail;
+ 
++  /* Check for existing components with the same name, but not for union
++     components or containers. Unions and maps are anonymous so they have
++     unique internal names which will never conflict.
++     Don't use gfc_find_component here because it calls gfc_use_derived,
++     but the derived type may not be fully defined yet. */
+   tail = NULL;
+ 
+   for (p = sym->components; p; p = p->next)
+@@ -1909,7 +1976,7 @@ gfc_add_component (gfc_symbol *sym, const char *name,
+     }
+ 
+   if (sym->attr.extension
+-	&& gfc_find_component (sym->components->ts.u.derived, name, true, true))
++	&& gfc_find_component (sym->components->ts.u.derived, name, true, true, NULL))
+     {
+       gfc_error_1 ("Component '%s' at %C already in the parent type "
+ 		 "at %L", name, &sym->components->ts.u.derived->declared_at);
+@@ -2000,7 +2067,7 @@ gfc_use_derived (gfc_symbol *sym)
+       return NULL;
+     }
+ 
+-  if (s == NULL || s->attr.flavor != FL_DERIVED)
++  if (s == NULL || !gfc_fl_struct (s->attr.flavor))
+     goto bad;
+ 
+   /* Get rid of symbol sym, translating all references to s.  */
+@@ -2033,30 +2100,110 @@ bad:
+   return NULL;
+ }
+ 
++   
++static gfc_component *
++find_union_component (gfc_symbol *un, const char *name,
++                      bool noaccess, gfc_ref **ref)
++{
++  gfc_component *m, *check;
++  gfc_ref *sref, *tmp;
++
++  for (m = un->components; m; m = m->next)
++  {
++    check = gfc_find_component (m->ts.u.derived, name, noaccess, true, &tmp);
++    if (check == NULL)
++      continue;
++
++    /* Found it somewhere in m; chain the refs together. */
++    if (ref)
++    {
++      /* Map ref. */
++      sref = gfc_get_ref ();
++      sref->type = REF_COMPONENT;
++      sref->u.c.component = m;
++      sref->u.c.sym = m->ts.u.derived;
++      sref->next = tmp;
++
++      *ref = sref;
++    }
++    /* Other checks (such as access) were done in the recursive calls.
++       Now we are done! */
++    return check;
++  }
++  return NULL;
++}
++
+ 
+ /* Given a derived type node and a component name, try to locate the
+    component structure.  Returns the NULL pointer if the component is
+    not found or the components are private.  If noaccess is set, no access
+-   checks are done.  */
++   checks are done. Unless silent is set, a gfc_error is generated when the
++   component cannot be found or accessed.
++   
++   If ref is not NULL, *ref is set to represent the chain of components
++   required to get to the ultimate component.
++
++   If the component is simply a direct subcomponent, or is inherited from a
++   parent derived type in the given derived type, this is a single ref with its
++   component set to the returned component.
++
++   Otherwise, *ref is constructed as a chain of subcomponents. This occurs
++   when the component is found through an implicit chain of nested union and
++   map components. Unions and maps are "anonymous" substructures in FORTRAN
++   which cannot be explicitly referenced, but the reference chain must be
++   considered as in C for backend translation to correctly compute layouts.
++   (For example, x.a may refer to x->(UNION)->(MAP)->(UNION)->(MAP)->a). */
+ 
+ gfc_component *
+ gfc_find_component (gfc_symbol *sym, const char *name,
+-		    bool noaccess, bool silent)
++		    bool noaccess, bool silent, gfc_ref **ref)
+ {
+-  gfc_component *p;
++  gfc_component *p, *check;
++  gfc_ref *sref = NULL, *tmp = NULL;
+ 
+   if (name == NULL || sym == NULL)
+     return NULL;
+ 
+-  sym = gfc_use_derived (sym);
++  if (sym->attr.flavor == FL_DERIVED)
++    sym = gfc_use_derived (sym);
++  else
++    gcc_assert (gfc_fl_struct (sym->attr.flavor));
+ 
+   if (sym == NULL)
+     return NULL;
+ 
++  /* Handle UNIONs specially. */
++  if (sym->attr.flavor == FL_UNION)
++    return find_union_component (sym, name, noaccess, ref);
++
++  if (ref) *ref = NULL;
+   for (p = sym->components; p; p = p->next)
+-    if (strcmp (p->name, name) == 0)
++  {
++    /* Nest search into union's maps. */
++    if (p->ts.type == BT_UNION)
++    {
++      check = find_union_component (p->ts.u.derived, name, noaccess, &tmp);
++      if (check != NULL)
++      {
++        /* Union ref. */
++        if (ref)
++        {
++          sref = gfc_get_ref ();
++          sref->type = REF_COMPONENT;
++          sref->u.c.component = p;
++          sref->u.c.sym = p->ts.u.derived;
++          sref->next = tmp;
++          *ref = sref;
++        }
++        return check;
++      }
++    }
++    else if (strcmp (p->name, name) == 0)
+       break;
+ 
++    continue;
++  }
++
+   if (p && sym->attr.use_assoc && !noaccess)
+     {
+       bool is_parent_comp = sym->attr.extension && (p == sym->components);
+@@ -2072,12 +2219,14 @@ gfc_find_component (gfc_symbol *sym, const char *name,
+ 	}
+     }
+ 
++  /* Look in the parent type. */
+   if (p == NULL
++        && sym->attr.flavor == FL_DERIVED
+ 	&& sym->attr.extension
+ 	&& sym->components->ts.type == BT_DERIVED)
+     {
+       p = gfc_find_component (sym->components->ts.u.derived, name,
+-			      noaccess, silent);
++			      noaccess, silent, ref);
+       /* Do not overwrite the error.  */
+       if (p == NULL)
+ 	return p;
+@@ -2087,6 +2236,25 @@ gfc_find_component (gfc_symbol *sym, const char *name,
+     gfc_error ("%qs at %C is not a member of the %qs structure",
+ 	       name, sym->name);
+ 
++  /* Component was found; build the ultimate component reference. */
++  if (p != NULL && ref)
++  {
++    tmp = gfc_get_ref ();
++    tmp->type = REF_COMPONENT;
++    tmp->u.c.component = p;
++    tmp->u.c.sym = sym;
++    /* Link the final component ref to the end of the chain of subrefs. */
++    if (sref)
++    {
++      *ref = sref;
++      for (; sref->next; sref = sref->next)
++        ;
++      sref->next = tmp;
++    }
++    else
++      *ref = tmp;
++  }
++
+   return p;
+ }
+ 
+@@ -3167,11 +3335,9 @@ gfc_restore_last_undo_checkpoint (void)
+ 	  /* The derived type is saved in the symtree with the first
+ 	     letter capitalized; the all lower-case version to the
+ 	     derived type contains its associated generic function.  */
+-	  if (p->attr.flavor == FL_DERIVED)
+-	    gfc_delete_symtree (&p->ns->sym_root, gfc_get_string ("%c%s",
+-                        (char) TOUPPER ((unsigned char) p->name[0]),
+-                        &p->name[1]));
+-	  else
++	  if (gfc_fl_struct (p->attr.flavor))
++	    gfc_delete_symtree (&p->ns->sym_root,gfc_dt_upper_string (p->name));
++          else
+ 	    gfc_delete_symtree (&p->ns->sym_root, p->name);
+ 
+ 	  gfc_release_symbol (p);
+@@ -3930,7 +4096,7 @@ verify_bind_c_derived_type (gfc_symbol *derived_sym)
+         }
+       
+       /* BIND(C) derived types must have interoperable components.  */
+-      if (curr_comp->ts.type == BT_DERIVED
++      if (gfc_bt_struct (curr_comp->ts.type)
+ 	  && curr_comp->ts.u.derived->ts.is_iso_c != 1 
+           && curr_comp->ts.u.derived != derived_sym)
+         {
+@@ -4355,10 +4521,8 @@ generate_isocbinding_symbol (const char *mod_name, iso_c_binding_symbol s,
+ 	      const char *hidden_name;
+ 	      gfc_interface *intr, *head;
+ 
+-	      hidden_name = gfc_get_string ("%c%s",
+-					    (char) TOUPPER ((unsigned char)
+-							      tmp_sym->name[0]),
+-					    &tmp_sym->name[1]);
++	      hidden_name = gfc_dt_upper_string (tmp_sym->name);
++
+ 	      tmp_symtree = gfc_find_symtree (gfc_current_ns->sym_root,
+ 					      hidden_name);
+ 	      gcc_assert (tmp_symtree == NULL);
+@@ -4569,15 +4733,21 @@ gfc_type_compatible (gfc_typespec *ts1, gfc_typespec *ts2)
+   bool is_class2 = (ts2->type == BT_CLASS);
+   bool is_derived1 = (ts1->type == BT_DERIVED);
+   bool is_derived2 = (ts2->type == BT_DERIVED);
++  bool is_union1 = (ts1->type == BT_UNION);
++  bool is_union2 = (ts2->type == BT_UNION);
+ 
+   if (is_class1
+       && ts1->u.derived->components
+       && ts1->u.derived->components->ts.u.derived->attr.unlimited_polymorphic)
+     return 1;
+ 
+-  if (!is_derived1 && !is_derived2 && !is_class1 && !is_class2)
++  if (!is_derived1 && !is_derived2 && !is_class1 && !is_class2
++      && !is_union1 && !is_union2)
+     return (ts1->type == ts2->type);
+ 
++  if (is_union1 && is_union2)
++    return gfc_compare_union_types (ts1->u.derived, ts2->u.derived);
++
+   if (is_derived1 && is_derived2)
+     return gfc_compare_derived_types (ts1->u.derived, ts2->u.derived);
+ 
+@@ -4639,12 +4809,12 @@ gfc_find_dt_in_generic (gfc_symbol *sym)
+ {
+   gfc_interface *intr = NULL;
+ 
+-  if (!sym || sym->attr.flavor == FL_DERIVED)
++  if (!sym || gfc_fl_struct (sym->attr.flavor))
+     return sym;
+ 
+   if (sym->attr.generic)
+     for (intr = sym->generic; intr; intr = intr->next)
+-      if (intr->sym->attr.flavor == FL_DERIVED)
++      if (gfc_fl_struct (intr->sym->attr.flavor))
+         break;
+   return intr ? intr->sym : NULL;
+ }
+diff --git a/gcc/fortran/target-memory.c b/gcc/fortran/target-memory.c
+index 4d63636..ffc7a7e 100644
+--- a/gcc/fortran/target-memory.c
++++ b/gcc/fortran/target-memory.c
+@@ -117,10 +117,10 @@ gfc_element_size (gfc_expr *e)
+ 
+     case BT_HOLLERITH:
+       return e->representation.length;
+-    case BT_DERIVED:
+     case BT_CLASS:
+     case BT_VOID:
+     case BT_ASSUMED:
++    case_struct_bt:
+       {
+ 	/* Determine type size without clobbering the typespec for ISO C
+ 	   binding types.  */
+@@ -291,6 +291,9 @@ gfc_target_encode_expr (gfc_expr *source, unsigned char *buffer,
+   if (source == NULL)
+     return 0;
+ 
++  /* Assumed no union will end up here. */
++  gcc_assert (source->ts.type != BT_UNION);
++
+   if (source->expr_type == EXPR_ARRAY)
+     return encode_array (source, buffer, buffer_size);
+ 
+@@ -616,6 +619,11 @@ gfc_target_interpret_expr (unsigned char *buffer, size_t buffer_size,
+       gcc_assert (result->representation.length >= 0);
+       break;
+ 
++    /* TODO: Handle BT_UNION ? */
++    case BT_UNION:
++      gfc_warning_now (0, "Union binary representation unimplemented");
++      break;
++
+     default:
+       gfc_internal_error ("Invalid expression in gfc_target_interpret_expr.");
+       break;
+@@ -662,7 +670,7 @@ expr_to_char (gfc_expr *e, unsigned char *data, unsigned char *chk, size_t len)
+ 
+   /* Take a derived type, one component at a time, using the offsets from the backend
+      declaration.  */
+-  if (e->ts.type == BT_DERIVED)
++  if (gfc_bt_struct (e->ts.type))
+     {
+       for (c = gfc_constructor_first (e->value.constructor),
+ 	   cmp = e->ts.u.derived->components;
+diff --git a/gcc/fortran/trans-decl.c b/gcc/fortran/trans-decl.c
+index 769d487..4767201 100644
+--- a/gcc/fortran/trans-decl.c
++++ b/gcc/fortran/trans-decl.c
+@@ -652,6 +652,7 @@ gfc_finish_var_decl (tree decl, gfc_symbol * sym)
+   if (!sym->ns->proc_name->attr.recursive
+       && INTEGER_CST_P (DECL_SIZE_UNIT (decl))
+       && !gfc_can_put_var_on_stack (DECL_SIZE_UNIT (decl))
++      && !sym->attr.automatic
+ 	 /* Put variable length auto array pointers always into stack.  */
+       && (TREE_CODE (TREE_TYPE (decl)) != POINTER_TYPE
+ 	  || sym->attr.dimension == 0
+@@ -751,22 +752,37 @@ gfc_get_module_backend_decl (gfc_symbol *sym)
+ 	  st->n.sym = sym;
+ 	  sym->refs++;
+ 	}
+-      else if (sym->attr.flavor == FL_DERIVED)
++      else if (gfc_fl_struct (sym->attr.flavor))
+ 	{
+ 	  if (s && s->attr.flavor == FL_PROCEDURE)
+ 	    {
+ 	      gfc_interface *intr;
+ 	      gcc_assert (s->attr.generic);
+ 	      for (intr = s->generic; intr; intr = intr->next)
+-		if (intr->sym->attr.flavor == FL_DERIVED)
++		if (gfc_fl_struct (intr->sym->attr.flavor))
+ 		  {
+ 		    s = intr->sym;
+ 		    break;
+ 		  }
+     	    }
+ 
+-	  if (!s->backend_decl)
+-	    s->backend_decl = gfc_get_derived_type (s);
++           /* Normally we can assume that s is a derived-type symbol since it
++              shares a name with the derived-type sym. However if sym is a
++              STRUCTURE, it may in fact share a name with any other basic type
++              variable. If s is in fact of derived type then we can continue
++              looking for a duplicate type declaration.  */
++           if (sym->attr.flavor == FL_STRUCT && s->ts.type == BT_DERIVED)
++             {
++               s = s->ts.u.derived;
++             }
++
++          if (gfc_fl_struct (s->attr.flavor) && !s->backend_decl)
++          {
++            if (s->attr.flavor == FL_UNION)
++              s->backend_decl = gfc_get_union_type (s);
++            else
++              s->backend_decl = gfc_get_derived_type (s);
++          }
+ 	  gfc_copy_dt_decls_ifequal (s, sym, true);
+ 	  return true;
+ 	}
+@@ -4438,7 +4454,7 @@ gfc_create_module_variable (gfc_symbol * sym)
+       && sym->ts.type == BT_DERIVED)
+     sym->backend_decl = gfc_typenode_for_spec (&(sym->ts));
+ 
+-  if (sym->attr.flavor == FL_DERIVED
++  if (gfc_fl_struct (sym->attr.flavor)
+       && sym->backend_decl
+       && TREE_CODE (sym->backend_decl) == RECORD_TYPE)
+     {
+@@ -4680,7 +4696,7 @@ check_constant_initializer (gfc_expr *expr, gfc_typespec *ts, bool array,
+     }
+   else switch (ts->type)
+     {
+-    case BT_DERIVED:
++    case_struct_bt:
+       if (expr->expr_type != EXPR_STRUCTURE)
+ 	return false;
+       cm = expr->ts.u.derived->components;
+diff --git a/gcc/fortran/trans-expr.c b/gcc/fortran/trans-expr.c
+index 88f1af8..80948e6 100644
+--- a/gcc/fortran/trans-expr.c
++++ b/gcc/fortran/trans-expr.c
+@@ -2172,6 +2172,7 @@ gfc_conv_component_ref (gfc_se * se, gfc_ref * ref)
+   tree tmp;
+   tree decl;
+   tree field;
++  tree context;
+ 
+   c = ref->u.c.component;
+ 
+@@ -2182,15 +2183,20 @@ gfc_conv_component_ref (gfc_se * se, gfc_ref * ref)
+   field = c->backend_decl;
+   gcc_assert (field && TREE_CODE (field) == FIELD_DECL);
+   decl = se->expr;
++  context = DECL_FIELD_CONTEXT (field);
+ 
+   /* Components can correspond to fields of different containing
+      types, as components are created without context, whereas
+      a concrete use of a component has the type of decl as context.
+      So, if the type doesn't match, we search the corresponding
+      FIELD_DECL in the parent type.  To not waste too much time
+-     we cache this result in norestrict_decl.  */
++     we cache this result in norestrict_decl. 
++     On the other hand, if the context is a UNION or a MAP (a
++     RECORD_TYPE within a UNION_TYPE) always use the given FIELD_DECL. */
+ 
+-  if (DECL_FIELD_CONTEXT (field) != TREE_TYPE (decl))
++  if (context != TREE_TYPE (decl) 
++      && !(   TREE_CODE (TREE_TYPE (field)) == UNION_TYPE /* field is union */
++           || TREE_CODE (context) == UNION_TYPE))         /* field is map */
+     {
+       tree f2 = c->norestrict_decl;
+       if (!f2 || DECL_FIELD_CONTEXT (f2) != TREE_TYPE (decl))
+@@ -6402,8 +6408,8 @@ gfc_conv_initializer (gfc_expr * expr, gfc_typespec * ts, tree type,
+     {
+       switch (ts->type)
+ 	{
+-	case BT_DERIVED:
+ 	case BT_CLASS:
++        case_struct_bt:
+ 	  gfc_init_se (&se, NULL);
+ 	  if (ts->type == BT_CLASS && expr->expr_type == EXPR_NULL)
+ 	    gfc_conv_structure (&se, gfc_class_initializer (ts, expr), 1);
+@@ -6547,7 +6553,7 @@ gfc_trans_alloc_subarray_assign (tree dest, gfc_component * cm,
+   gfc_add_modify (&block, dest, se.expr);
+ 
+   /* Deal with arrays of derived types with allocatable components.  */
+-  if (cm->ts.type == BT_DERIVED
++  if (gfc_bt_struct (cm->ts.type)
+ 	&& cm->ts.u.derived->attr.alloc_comp)
+     tmp = gfc_copy_alloc_comp (cm->ts.u.derived,
+ 			       se.expr, dest,
+@@ -6720,7 +6726,7 @@ alloc_scalar_allocatable_for_subcomponent_assignment (stmtblock_t *block,
+       /* Ensure that cm->ts.u.cl->backend_decl is a componentref to _%s_length
+ 	 component.  */
+       sprintf (name, "_%s_length", cm->name);
+-      strlen = gfc_find_component (sym, name, true, true);
++      strlen = gfc_find_component (sym, name, true, true, NULL);
+       lhs_cl_size = fold_build3_loc (input_location, COMPONENT_REF,
+ 				     gfc_charlen_type_node,
+ 				     TREE_OPERAND (comp, 0),
+@@ -6908,7 +6914,9 @@ gfc_trans_subcomponent_assign (tree dest, gfc_component * cm, gfc_expr * expr,
+ 			fold_convert (TREE_TYPE (tmp), se.expr));
+       gfc_add_block_to_block (&block, &se.post);
+     }
+-  else if (expr->ts.type == BT_DERIVED && expr->ts.f90_type != BT_VOID)
++
++  // TODO: Not sure if this is expr->ts.type or cm->ts.type. check.
++  else if (gfc_bt_struct (expr->ts.type) && expr->ts.f90_type != BT_VOID)
+     {
+       if (expr->expr_type != EXPR_STRUCTURE)
+ 	{
+@@ -7067,6 +7075,23 @@ gfc_conv_structure (gfc_se * se, gfc_expr * expr, int init)
+       return;
+     }
+ 
++  /* Though unions appear to have multiple map components, they must only
++     have a single initializer since each map overlaps. */
++  if (expr->ts.type == BT_UNION)
++  {
++    c = gfc_constructor_first (expr->value.constructor);
++    cm = c->n.component;
++    val = gfc_conv_initializer (c->expr, &expr->ts,
++                                TREE_TYPE (cm->backend_decl),
++                                cm->attr.dimension, cm->attr.pointer,
++                                cm->attr.proc_pointer);
++    val = unshare_expr_without_location (val);
++
++    /* Append it to the constructor list.  */
++    CONSTRUCTOR_APPEND_ELT (v, cm->backend_decl, val);
++    goto finish;
++  }
++
+   cm = expr->ts.u.derived->components;
+ 
+   for (c = gfc_constructor_first (expr->value.constructor);
+@@ -7113,6 +7138,7 @@ gfc_conv_structure (gfc_se * se, gfc_expr * expr, int init)
+ 	  CONSTRUCTOR_APPEND_ELT (v, cm->backend_decl, val);
+ 	}
+     }
++finish:
+   se->expr = build_constructor (type, v);
+   if (init)
+     TREE_CONSTANT (se->expr) = 1;
+@@ -7913,7 +7939,7 @@ gfc_trans_scalar_assign (gfc_se * lse, gfc_se * rse, gfc_typespec ts,
+       gfc_trans_string_copy (&block, llen, lse->expr, ts.kind, rlen,
+ 			     rse->expr, ts.kind);
+     }
+-  else if (ts.type == BT_DERIVED && ts.u.derived->attr.alloc_comp)
++  else if (gfc_bt_struct (ts.type) && ts.u.derived->attr.alloc_comp)
+     {
+       tree tmp_var = NULL_TREE;
+       cond = NULL_TREE;
+@@ -7966,7 +7992,7 @@ gfc_trans_scalar_assign (gfc_se * lse, gfc_se * rse, gfc_typespec ts,
+ 	  gfc_add_expr_to_block (&block, tmp);
+ 	}
+     }
+-  else if (ts.type == BT_DERIVED || ts.type == BT_CLASS)
++  else if (gfc_bt_struct (ts.type) || ts.type == BT_CLASS)
+     {
+       gfc_add_block_to_block (&block, &lse->pre);
+       gfc_add_block_to_block (&block, &rse->pre);
+@@ -9116,7 +9142,7 @@ copyable_array_p (gfc_expr * expr)
+     case BT_CHARACTER:
+       return false;
+ 
+-    case BT_DERIVED:
++    case_struct_bt:
+       return !expr->ts.u.derived->attr.alloc_comp;
+ 
+     default:
+diff --git a/gcc/fortran/trans-io.c b/gcc/fortran/trans-io.c
+index aa14706..e7542a6 100644
+--- a/gcc/fortran/trans-io.c
++++ b/gcc/fortran/trans-io.c
+@@ -1697,7 +1697,7 @@ transfer_namelist_element (stmtblock_t * block, const char * var_name,
+       gfc_add_expr_to_block (block, tmp);
+     }
+ 
+-  if (ts->type == BT_DERIVED && ts->u.derived->components)
++  if (gfc_bt_struct (ts->type) && ts->u.derived->components)
+     {
+       gfc_component *cmp;
+ 
+@@ -2223,7 +2223,7 @@ transfer_expr (gfc_se * se, gfc_typespec * ts, tree addr_expr, gfc_code * code)
+ 
+       break;
+ 
+-    case BT_DERIVED:
++    case_struct_bt:
+       if (ts->u.derived->components == NULL)
+ 	return;
+ 
+@@ -2342,7 +2342,7 @@ gfc_trans_transfer (gfc_code * code)
+ 	  gcc_assert (ref && ref->type == REF_ARRAY);
+ 	}
+ 
+-      if (expr->ts.type != BT_DERIVED
++      if (!gfc_bt_struct (expr->ts.type)
+ 	    && ref && ref->next == NULL
+ 	    && !is_subref_array (expr))
+ 	{
+diff --git a/gcc/fortran/trans-openmp.c b/gcc/fortran/trans-openmp.c
+index 98aeaad..b34ceee 100644
+--- a/gcc/fortran/trans-openmp.c
++++ b/gcc/fortran/trans-openmp.c
+@@ -1482,7 +1482,7 @@ gfc_trans_omp_array_reduction_or_udr (tree c, gfc_omp_namelist *n, locus where)
+   else if (udr->initializer_ns == NULL)
+     {
+       gcc_assert (sym->ts.type == BT_DERIVED);
+-      e2 = gfc_default_initializer (&sym->ts);
++      e2 = gfc_default_initializer (&sym->ts, false);
+       gcc_assert (e2);
+       t = gfc_resolve_expr (e2);
+       gcc_assert (t);
+diff --git a/gcc/fortran/trans-stmt.c b/gcc/fortran/trans-stmt.c
+index 91d2a85..c58d1b5 100644
+--- a/gcc/fortran/trans-stmt.c
++++ b/gcc/fortran/trans-stmt.c
+@@ -5900,7 +5900,7 @@ gfc_trans_deallocate (gfc_code *code)
+ 	{
+ 	  gfc_ref *ref;
+ 
+-	  if (expr->ts.type == BT_DERIVED && expr->ts.u.derived->attr.alloc_comp
++	  if (gfc_bt_struct (expr->ts.type) && expr->ts.u.derived->attr.alloc_comp
+ 	      && !gfc_is_finalizable (expr->ts.u.derived, NULL))
+ 	    {
+ 	      gfc_ref *last = NULL;
+diff --git a/gcc/fortran/trans-types.c b/gcc/fortran/trans-types.c
+index 0ad8ac2..056637c 100644
+--- a/gcc/fortran/trans-types.c
++++ b/gcc/fortran/trans-types.c
+@@ -1121,6 +1121,10 @@ gfc_typenode_for_spec (gfc_typespec * spec)
+ 					     gfc_index_one_node);
+       break;
+ 
++    case BT_UNION:
++      basetype = gfc_get_union_type (spec->u.derived);
++      break;
++
+     case BT_DERIVED:
+     case BT_CLASS:
+       basetype = gfc_get_derived_type (spec->u.derived);
+@@ -2358,6 +2362,61 @@ gfc_get_ppc_type (gfc_component* c)
+   return build_pointer_type (build_function_type_list (t, NULL_TREE));
+ }
+ 
++/* Build a tree node for a union type. Requires building each map
++   structure which is an element of the union. */
++
++tree
++gfc_get_union_type (gfc_symbol *un)
++{
++    gfc_component *map = NULL;
++    tree typenode = NULL, map_type = NULL, map_field = NULL;
++    tree *chain = NULL;
++
++    if (un->backend_decl)
++    {
++      if (TYPE_FIELDS (un->backend_decl) || un->attr.proc_pointer_comp)
++        return un->backend_decl;
++      else
++        typenode = un->backend_decl;
++    }
++    else
++    {
++      typenode = make_node (UNION_TYPE);
++      TYPE_NAME (typenode) = get_identifier (un->name);
++    }
++
++    /* Add each contained MAP as a field. */
++    for (map = un->components; map; map = map->next)
++    {
++        gcc_assert (map->ts.type == BT_DERIVED);
++
++        /* The map's type node, which is defined within this union's context. */
++        map_type = gfc_get_derived_type (map->ts.u.derived);
++        TYPE_CONTEXT (map_type) = typenode;
++
++        /* The map field's declaration. */
++        map_field = gfc_add_field_to_struct(typenode, get_identifier(map->name),
++                                            map_type, &chain);
++        if (map->loc.lb)
++          gfc_set_decl_location (map_field, &map->loc);
++        else if (un->declared_at.lb)
++          gfc_set_decl_location (map_field, &un->declared_at);
++
++        DECL_PACKED (map_field) |= TYPE_PACKED (typenode);
++        DECL_NAMELESS(map_field) = true;
++
++        /* We should never clobber another backend declaration for this map,
++           because each map component is unique. */
++        if (!map->backend_decl)
++          map->backend_decl = map_field;
++    }
++
++    un->backend_decl = typenode;
++    gfc_finish_type (typenode);
++
++    return typenode;
++}
++
+ 
+ /* Build a tree node for a derived type.  If there are equal
+    derived types, with different local names, these are built
+@@ -2523,7 +2582,10 @@ gfc_get_derived_type (gfc_symbol * derived)
+     return derived->backend_decl;
+ 
+   /* Build the type member list. Install the newly created RECORD_TYPE
+-     node as DECL_CONTEXT of each FIELD_DECL.  */
++     node as DECL_CONTEXT of each FIELD_DECL. In this case we must go
++     through only the top-level linked list of components so we correctly
++     build UNION_TYPE nodes for BT_UNION components. MAPs and other nested
++     types are built as part of gfc_get_union_type. */
+   for (c = derived->components; c; c = c->next)
+     {
+       if (c->attr.proc_pointer)
+diff --git a/gcc/fortran/trans.c b/gcc/fortran/trans.c
+index 549e921..356c467 100644
+--- a/gcc/fortran/trans.c
++++ b/gcc/fortran/trans.c
+@@ -902,7 +902,7 @@ gfc_build_final_call (gfc_typespec ts, gfc_expr *final_wrapper, gfc_expr *var,
+   if (POINTER_TYPE_P (TREE_TYPE (final_fndecl)))
+     final_fndecl = build_fold_indirect_ref_loc (input_location, final_fndecl);
+ 
+-  if (ts.type == BT_DERIVED)
++  if (gfc_bt_struct (ts.type))
+     {
+       tree elem_size;
+ 
+@@ -990,7 +990,6 @@ gfc_build_final_call (gfc_typespec ts, gfc_expr *final_wrapper, gfc_expr *var,
+   return gfc_finish_block (&block);
+ }
+ 
+-
+ bool
+ gfc_add_comp_finalizer_call (stmtblock_t *block, tree decl, gfc_component *comp,
+ 			     bool fini_coarray)
+@@ -1381,6 +1380,7 @@ gfc_deallocate_with_status (tree pointer, tree status, tree errmsg,
+ }
+ 
+ 
++
+ /* Generate code for deallocation of allocatable scalars (variables or
+    components). Before the object itself is freed, any allocatable
+    subcomponents are being deallocated.  */
+@@ -1437,7 +1437,7 @@ gfc_deallocate_scalar_with_status (tree pointer, tree status, bool can_fail,
+ 
+   /* Free allocatable components.  */
+   finalizable = gfc_add_finalizer_call (&non_null, expr);
+-  if (!finalizable && ts.type == BT_DERIVED && ts.u.derived->attr.alloc_comp)
++  if (!finalizable && gfc_bt_struct(ts.type) && ts.u.derived->attr.alloc_comp)
+     {
+       tmp = build_fold_indirect_ref_loc (input_location, pointer);
+       tmp = gfc_deallocate_alloc_comp (ts.u.derived, tmp, 0);
+diff --git a/gcc/testsuite/gfortran.dg/array_6.f90 b/gcc/testsuite/gfortran.dg/array_6.f90
+new file mode 100644
+index 0000000..20752a1
+--- /dev/null
++++ b/gcc/testsuite/gfortran.dg/array_6.f90
+@@ -0,0 +1,13 @@
++! { dg-do compile }
++! { dg-options "-std=extra-legacy" }!
++! Checks that under-specified arrays (referencing arrays with fewer
++! dimensions than the array spec) generates a warning.
++!
++! Contributed by Jim MacArthur <jim.macarthur@codethink.co.uk>
++!
++
++program under_specified_array
++    INTEGER chsbrd(8,8)
++    chsbrd(3,1) = 5
++    print *, chsbrd(3) ! { dg-warning "Using the lower bound for unspecified dimensions in array reference" }
++end program
+diff --git a/gcc/testsuite/gfortran.dg/automatic_1.f90 b/gcc/testsuite/gfortran.dg/automatic_1.f90
+new file mode 100644
+index 0000000..a7684e9
+--- /dev/null
++++ b/gcc/testsuite/gfortran.dg/automatic_1.f90
+@@ -0,0 +1,31 @@
++! { dg-do run }
++! { dg-options "-O2 -std=legacy -fno-automatic" }
++      subroutine foo (b)
++        logical b
++        integer i, j
++        character*24 s
++        automatic i
++        if (b) then
++          i = 26
++          j = 131
++          s = 'This is a test string'
++        else
++          if (i .eq. 26 .or. j .ne. 131) call abort
++          if (s .ne. 'This is a test string') call abort
++        end if
++      end subroutine foo
++      subroutine bar (s)
++        character*42 s
++        if (s .ne. '0123456789012345678901234567890123456') call abort
++        call foo (.false.)
++      end subroutine bar
++      subroutine baz
++        character*42 s
++        ! Just clobber stack a little bit.
++        s = '0123456789012345678901234567890123456'
++        call bar (s)
++      end subroutine baz
++      call foo (.true.)
++      call baz
++      call foo (.false.)
++      end
+diff --git a/gcc/testsuite/gfortran.dg/automatic_common.f90 b/gcc/testsuite/gfortran.dg/automatic_common.f90
+new file mode 100644
+index 0000000..df8b7dc
+--- /dev/null
++++ b/gcc/testsuite/gfortran.dg/automatic_common.f90
+@@ -0,0 +1,6 @@
++! { dg-do compile }
++! { dg-options "-std=legacy -fno-automatic" }
++! A common variable may not have the AUTOMATIC attribute.
++INTEGER, AUTOMATIC :: X
++COMMON /COM/ X ! { dg-error "conflicts with AUTOMATIC attribute" }
++END
+diff --git a/gcc/testsuite/gfortran.dg/automatic_data.f90 b/gcc/testsuite/gfortran.dg/automatic_data.f90
+new file mode 100644
+index 0000000..16203e3
+--- /dev/null
++++ b/gcc/testsuite/gfortran.dg/automatic_data.f90
+@@ -0,0 +1,9 @@
++! { dg-do compile }
++! { dg-options "-std=legacy -fno-automatic" }
++! An AUTOMATIC statement cannot be used with SAVE
++FUNCTION X()
++DATA y/2.5/
++AUTOMATIC y ! { dg-error "DATA attribute conflicts with AUTOMATIC attribute" }
++y = 1
++END FUNCTION X
++END
+diff --git a/gcc/testsuite/gfortran.dg/automatic_repeat.f90 b/gcc/testsuite/gfortran.dg/automatic_repeat.f90
+new file mode 100644
+index 0000000..9bc85ec
+--- /dev/null
++++ b/gcc/testsuite/gfortran.dg/automatic_repeat.f90
+@@ -0,0 +1,8 @@
++! { dg-do compile }
++! { dg-options "-std=legacy -fno-automatic" }
++! An AUTOMATIC statement cannot duplicated
++FUNCTION X()
++REAL, AUTOMATIC, AUTOMATIC :: Y ! { dg-error "Duplicate AUTOMATIC attribute" }
++y = 1
++END FUNCTION X
++END
+diff --git a/gcc/testsuite/gfortran.dg/automatic_save.f90 b/gcc/testsuite/gfortran.dg/automatic_save.f90
+new file mode 100644
+index 0000000..5e20643
+--- /dev/null
++++ b/gcc/testsuite/gfortran.dg/automatic_save.f90
+@@ -0,0 +1,8 @@
++! { dg-do compile }
++! { dg-options "-std=legacy -fno-automatic" }
++! An AUTOMATIC statement cannot be used with SAVE
++FUNCTION X()
++REAL, SAVE, AUTOMATIC :: Y ! { dg-error "SAVE attribute conflicts with AUTOMATIC attribute" }
++y = 1
++END FUNCTION X
++END
+diff --git a/gcc/testsuite/gfortran.dg/c_ptr_tests_16.f90 b/gcc/testsuite/gfortran.dg/c_ptr_tests_16.f90
+index 8855d62..118ee37 100644
+--- a/gcc/testsuite/gfortran.dg/c_ptr_tests_16.f90
++++ b/gcc/testsuite/gfortran.dg/c_ptr_tests_16.f90
+@@ -13,7 +13,8 @@ program test
+   print '(z8)', a
+   if (     int(z'45434241') /= a  &
+      .and. int(z'41424345') /= a  &
+-     .and. int(z'4142434500000000',kind=8) /= a) &
++     .and. int(z'4142434520202020',kind=8) /= a &
++     .and. int(z'2020202045434241',kind=8) /= a ) &
+     call i_do_not_exist()
+ end program test
+ 
+diff --git a/gcc/testsuite/gfortran.dg/duplicate_type_2.f90 b/gcc/testsuite/gfortran.dg/duplicate_type_2.f90
+index 0fd9258..4fb8088 100644
+--- a/gcc/testsuite/gfortran.dg/duplicate_type_2.f90
++++ b/gcc/testsuite/gfortran.dg/duplicate_type_2.f90
+@@ -14,10 +14,10 @@ END FUNCTION foo
+ 
+ INTEGER FUNCTION bar () RESULT (x)
+   IMPLICIT NONE
+-  INTEGER :: x ! { dg-error "basic type of" }
++  INTEGER :: x ! { dg-warning "basic type of" }
+ 
+   INTEGER :: y
+-  INTEGER :: y ! { dg-error "basic type of" }
++  INTEGER :: y ! { dg-warning "basic type of" }
+ 
+   x = 42
+ END FUNCTION bar
+diff --git a/gcc/testsuite/gfortran.dg/duplicate_type_4.f90 b/gcc/testsuite/gfortran.dg/duplicate_type_4.f90
+new file mode 100644
+index 0000000..cdd29ea
+--- /dev/null
++++ b/gcc/testsuite/gfortran.dg/duplicate_type_4.f90
+@@ -0,0 +1,13 @@
++! { dg-do compile }
++! { dg-options "-std=f95" }
++
++! PR fortran/30239
++! Check for errors when a symbol gets declared a type twice, even if it
++! is the same.
++
++INTEGER FUNCTION foo ()
++  IMPLICIT NONE
++  INTEGER :: x
++  INTEGER :: x ! { dg-error "basic type of" }
++  x = 42
++END FUNCTION foo
+diff --git a/gcc/testsuite/gfortran.dg/func_decl_2.f90 b/gcc/testsuite/gfortran.dg/func_decl_2.f90
+index 658883e..5459b1c 100644
+--- a/gcc/testsuite/gfortran.dg/func_decl_2.f90
++++ b/gcc/testsuite/gfortran.dg/func_decl_2.f90
+@@ -1,4 +1,6 @@
+ ! { dg-do compile }
++! { dg-options "-std=f95" }
++
+ ! Test fix for PR16943 in which the double typing of
+ ! N caused an error.
+ !
+diff --git a/gcc/testsuite/gfortran.dg/hollerith-character-comparison.f90 b/gcc/testsuite/gfortran.dg/hollerith-character-comparison.f90
+new file mode 100644
+index 0000000..9c462b9
+--- /dev/null
++++ b/gcc/testsuite/gfortran.dg/hollerith-character-comparison.f90
+@@ -0,0 +1,15 @@
++       ! { dg-options "-std=extra-legacy" }
++
++      program convert
++      REAL*4 a
++      INTEGER*4 b
++      b = 1000
++      print *, 4HJMAC.eq.4HJMAC ! { dg-warning "Promoting argument for comparison from HOLLERITH to CHARACTER at" }
++      print *, 4HJMAC.eq."JMAC" ! { dg-warning "Promoting argument for comparison from HOLLERITH to CHARACTER at" }
++      print *, 4HJMAC.eq."JMAN" ! { dg-warning "Promoting argument for comparison from HOLLERITH to CHARACTER at" }
++      print *, "JMAC".eq.4HJMAN !  { dg-warning "Promoting argument for comparison from HOLLERITH to CHARACTER at" }
++      print *, "AAAA".eq.5HAAAAA ! { dg-warning "Promoting argument for comparison from HOLLERITH to CHARACTER at" }
++      print *, "BBBBB".eq.5HBBBB ! { dg-warning "Promoting argument for comparison from HOLLERITH to CHARACTER at" }
++
++      end program
++
+diff --git a/gcc/testsuite/gfortran.dg/hollerith-int-comparison.f90 b/gcc/testsuite/gfortran.dg/hollerith-int-comparison.f90
+new file mode 100644
+index 0000000..f44c1f8
+--- /dev/null
++++ b/gcc/testsuite/gfortran.dg/hollerith-int-comparison.f90
+@@ -0,0 +1,11 @@
++       ! { dg-options "-std=extra-legacy" }
++
++      program convert
++      INTEGER*4 b
++      b = 5HRIVET ! { dg-warning "Legacy Extension: Hollerith constant|Conversion from HOLLERITH to INTEGER|too long to convert" }
++      print *, 4HJMAC.eq.400 ! { dg-warning "Legacy Extension: Hollerith constant|Promoting argument for comparison from character|Conversion from HOLLERITH to INTEGER" }
++      print *, 4HRIVE.eq.1163282770 ! { dg-warning "Legacy Extension: Hollerith constant|Promoting argument for comparison from character|Conversion from HOLLERITH to INTEGER" }
++      print *, b
++      print *, 1163282770.eq.4HRIVE ! { dg-warning "Legacy Extension: Hollerith constant|Promoting argument for comparison from character|Conversion from HOLLERITH to INTEGER" }
++      end program
++
+diff --git a/gcc/testsuite/gfortran.dg/vax_structure_1.f90 b/gcc/testsuite/gfortran.dg/vax_structure_1.f90
+new file mode 100644
+index 0000000..2658c12
+--- /dev/null
++++ b/gcc/testsuite/gfortran.dg/vax_structure_1.f90
+@@ -0,0 +1,27 @@
++! { dg-do compile }
++! { dg-options "-fdec-structure" }
++! Tests the VAX STRUCTURE and RECORD statements.
++! These are syntactic sugar for TYPE statements.
++
++      program vax_structure_1
++      structure /stocklevel/
++         integer*2   A
++         integer*4   B
++         integer*4   CS(0:15)
++         byte        D(0:15)
++      end structure
++
++      record /stocklevel/ rec1, recs(100)
++      integer x
++      integer*2 y
++
++      rec1.A = 100
++      recs(100).CS(10)=1
++      x = 150
++      y = 150
++
++      print *, rec1.B.eq.100
++      print *, rec1.A.eq.x ! {dg-error "are INTEGER(2)/INTEGER(4)"}
++      print *, rec1.A.eq.y
++      print *, recs(100).CS(10)
++      end program
+diff --git a/libgfortran/io/format.c b/libgfortran/io/format.c
+index fa81d9b..e7cc1ba 100644
+--- a/libgfortran/io/format.c
++++ b/libgfortran/io/format.c
+@@ -918,15 +918,26 @@ parse_format_list (st_parameter_dt *dtp, bool *seen_dd)
+ 	{
+ 	  if (u != FMT_POSINT && u != FMT_ZERO)
+ 	    {
+-	      fmt->error = nonneg_required;
+-	      goto finished;
++	      tail->u.real.w = DEFAULT_WIDTH;
++	      tail->u.real.d = 0;
++	      tail->u.real.e = -1;
++	      fmt->saved_token = u;
++	      break;
+ 	    }
+ 	}
+-      else if (u != FMT_POSINT)
++      else if (u == FMT_ZERO)
+ 	{
+ 	  fmt->error = posint_required;
+ 	  goto finished;
+ 	}
++      else if (u != FMT_POSINT)
++	{
++	  tail->u.real.w = DEFAULT_WIDTH;
++	  tail->u.real.d = 0;
++	  tail->u.real.e = -1;
++	  fmt->saved_token = u;
++	  break;
++	}
+ 
+       tail->u.real.w = fmt->value;
+       t2 = t;
+@@ -1016,8 +1027,10 @@ parse_format_list (st_parameter_dt *dtp, bool *seen_dd)
+ 	{
+ 	  if (t != FMT_ZERO && t != FMT_POSINT)
+ 	    {
+-	      fmt->error = nonneg_required;
+-	      goto finished;
++	      tail->u.integer.w = DEFAULT_WIDTH;
++	      tail->u.integer.m = -1;
++	      fmt->saved_token = t;
++	      break;
+ 	    }
+ 	}
+ 
+diff --git a/libgfortran/io/io.h b/libgfortran/io/io.h
+index f34d0c3..b8ee61c 100644
+--- a/libgfortran/io/io.h
++++ b/libgfortran/io/io.h
+@@ -847,5 +847,8 @@ memset4 (gfc_char4_t *p, gfc_char4_t c, int k)
+     *p++ = c;
+ }
+ 
++/* Used in width fields to indicate that the default should be used */
++#define DEFAULT_WIDTH -1
++
+ #endif
+ 
+diff --git a/libgfortran/io/write.c b/libgfortran/io/write.c
+index 7599659..a5dac4f 100644
+--- a/libgfortran/io/write.c
++++ b/libgfortran/io/write.c
+@@ -547,9 +547,24 @@ write_l (st_parameter_dt *dtp, const fnode *f, char *source, int len)
+   p[wlen - 1] = (n) ? 'T' : 'F';
+ }
+ 
++static int
++default_width_for_len (int len)
++{
++  /* No width was specified in the format string, which is a legacy extension -
++     choose a default based on the data width.  */
++  switch (len)
++    {
++    case 1:
++    case 2:  return  7;
++    case 4:  return 12;
++    case 8:  return 23;
++    case 16: return 44;
++    default: return  0;
++    }
++}
+ 
+ static void
+-write_boz (st_parameter_dt *dtp, const fnode *f, const char *q, int n)
++write_boz (st_parameter_dt *dtp, const fnode *f, const char *q, int n, int len)
+ {
+   int w, m, digits, nzero, nblank;
+   char *p;
+@@ -582,6 +597,9 @@ write_boz (st_parameter_dt *dtp, const fnode *f, const char *q, int n)
+   /* Select a width if none was specified.  The idea here is to always
+      print something.  */
+ 
++  if (w == DEFAULT_WIDTH)
++    w = default_width_for_len (len);
++
+   if (w == 0)
+     w = ((digits < m) ? m : digits);
+ 
+@@ -708,6 +726,8 @@ write_decimal (st_parameter_dt *dtp, const fnode *f, const char *source,
+ 
+   /* Select a width if none was specified.  The idea here is to always
+      print something.  */
++  if (w == DEFAULT_WIDTH)
++    w = default_width_for_len(len);
+ 
+   if (w == 0)
+     w = ((digits < m) ? m : digits) + nsign;
+@@ -1091,13 +1111,13 @@ write_b (st_parameter_dt *dtp, const fnode *f, const char *source, int len)
+   if (len > (int) sizeof (GFC_UINTEGER_LARGEST))
+     {
+       p = btoa_big (source, itoa_buf, len, &n);
+-      write_boz (dtp, f, p, n);
++      write_boz (dtp, f, p, n, len);
+     }
+   else
+     {
+       n = extract_uint (source, len);
+       p = btoa (n, itoa_buf, sizeof (itoa_buf));
+-      write_boz (dtp, f, p, n);
++      write_boz (dtp, f, p, n, len);
+     }
+ }
+ 
+@@ -1112,13 +1132,13 @@ write_o (st_parameter_dt *dtp, const fnode *f, const char *source, int len)
+   if (len > (int) sizeof (GFC_UINTEGER_LARGEST))
+     {
+       p = otoa_big (source, itoa_buf, len, &n);
+-      write_boz (dtp, f, p, n);
++      write_boz (dtp, f, p, n, len);
+     }
+   else
+     {
+       n = extract_uint (source, len);
+       p = otoa (n, itoa_buf, sizeof (itoa_buf));
+-      write_boz (dtp, f, p, n);
++      write_boz (dtp, f, p, n, len);
+     }
+ }
+ 
+@@ -1132,13 +1152,13 @@ write_z (st_parameter_dt *dtp, const fnode *f, const char *source, int len)
+   if (len > (int) sizeof (GFC_UINTEGER_LARGEST))
+     {
+       p = ztoa_big (source, itoa_buf, len, &n);
+-      write_boz (dtp, f, p, n);
++      write_boz (dtp, f, p, n, len);
+     }
+   else
+     {
+       n = extract_uint (source, len);
+       p = gfc_xtoa (n, itoa_buf, sizeof (itoa_buf));
+-      write_boz (dtp, f, p, n);
++      write_boz (dtp, f, p, n, len);
+     }
+ }
+ 
+diff --git a/libgfortran/io/write_float.def b/libgfortran/io/write_float.def
+index 1bbe016..c64303c 100644
+--- a/libgfortran/io/write_float.def
++++ b/libgfortran/io/write_float.def
+@@ -112,7 +112,7 @@ determine_precision (st_parameter_dt * dtp, const fnode * f, int len)
+ 
+ static bool
+ output_float (st_parameter_dt *dtp, const fnode *f, char *buffer, size_t size,
+-	      int nprinted, int precision, int sign_bit, bool zero_flag)
++	      int nprinted, int precision, int sign_bit, bool zero_flag, int width)
+ {
+   char *out;
+   char *digits;
+@@ -131,8 +131,16 @@ output_float (st_parameter_dt *dtp, const fnode *f, char *buffer, size_t size,
+   sign_t sign;
+ 
+   ft = f->format;
+-  w = f->u.real.w;
+-  d = f->u.real.d;
++  if (f->u.real.w == DEFAULT_WIDTH)
++    {
++      w = width;
++      d = precision;
++    }
++  else
++    {
++      w = f->u.real.w;
++      d = f->u.real.d;
++    }
+   p = dtp->u.p.scale_factor;
+ 
+   rchar = '5';
+@@ -1009,7 +1017,7 @@ __qmath_(quadmath_snprintf) (buffer, size, "%+-#.*Qf", \
+ static void \
+ output_float_FMT_G_ ## x (st_parameter_dt *dtp, const fnode *f, \
+ 		      GFC_REAL_ ## x m, char *buffer, size_t size, \
+-			  int sign_bit, bool zero_flag, int comp_d) \
++			  int sign_bit, bool zero_flag, int comp_d, int width) \
+ { \
+   int e = f->u.real.e;\
+   int d = f->u.real.d;\
+@@ -1106,7 +1114,7 @@ output_float_FMT_G_ ## x (st_parameter_dt *dtp, const fnode *f, \
+ \
+  finish:\
+     result = output_float (dtp, &newf, buffer, size, nprinted, precision,\
+-			   sign_bit, zero_flag);\
++			   sign_bit, zero_flag, width);\
+   dtp->u.p.scale_factor = save_scale_factor;\
+ \
+ \
+@@ -1245,7 +1253,7 @@ determine_en_precision (st_parameter_dt *dtp, const fnode *f,
+ 	zero_flag = (tmp == 0.0);\
+ 	if (f->format == FMT_G)\
+ 	  output_float_FMT_G_ ## x (dtp, f, tmp, buffer, size, sign_bit, \
+-				    zero_flag, comp_d);\
++				    zero_flag, comp_d, width);\
+ 	else\
+ 	  {\
+ 	    if (f->format == FMT_F)\
+@@ -1253,7 +1261,7 @@ determine_en_precision (st_parameter_dt *dtp, const fnode *f,
+ 	    else\
+ 	      nprinted = DTOA(y,precision,tmp);					\
+ 	    output_float (dtp, f, buffer, size, nprinted, precision,\
+-			  sign_bit, zero_flag);\
++			  sign_bit, zero_flag, width);\
+ 	  }\
+ }\
+ 
+@@ -1265,14 +1273,36 @@ write_float (st_parameter_dt *dtp, const fnode *f, const char *source, \
+ {
+   int sign_bit, nprinted;
+   int precision;  /* Precision for snprintf call.  */
++  int width;
+   bool zero_flag;
+ 
+-  if (f->format != FMT_EN)
+-    precision = determine_precision (dtp, f, len);
+-  else
+-    precision = determine_en_precision (dtp, f, source, len);
++  precision = 0;
++  width = 0;
++
++  if (f->u.real.w == DEFAULT_WIDTH)
++    { /* Set defaults based on size (and type also, but that's TODO) */
++      switch(len)
++        {
++            case 4: width = 15; precision = 7; break;
++	    case 8: width = 25; precision = 16; break;
++	    case 16: width = 42; precision = 33; break;
++        }
++    }
++
++  if (width == 0)
++    {
++       width = f->u.real.w;
++    }
++
++  if (precision == 0)
++    {
++      if (f->format != FMT_EN)
++        precision = determine_precision (dtp, f, len);
++      else
++        precision = determine_en_precision (dtp, f, source, len);
++    }
+ 
+-  /* 4932 is the maximum exponent of long double and quad precision, 3
++   /* 4932 is the maximum exponent of long double and quad precision, 3
+      extra characters for the sign, the decimal point, and the
+      trailing null, and finally some extra digits depending on the
+      requested precision.  */


### PR DESCRIPTION
This is the legacy Fortran patch for dts-4, gcc 5.2 branch. You've probably made this already but thought I'd raise it just in case.
